### PR TITLE
M0: Config schema + strict validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,58 @@
+package config
+
+import "time"
+
+const (
+	SouthboundTransportSerial = "serial"
+	SouthboundTransportTCP    = "tcp"
+)
+
+type Config struct {
+	Southbound   SouthboundConfig
+	Northbound   NorthboundConfig
+	Clients      ClientsConfig
+	Scheduler    SchedulerConfig
+	AddressGuard AddressGuardConfig
+	Emulation    EmulationConfig
+}
+
+type SouthboundConfig struct {
+	Transport string
+	Serial    SerialSouthboundConfig
+	TCP       TCPSouthboundConfig
+}
+
+type SerialSouthboundConfig struct {
+	Device   string
+	BaudRate int
+}
+
+type TCPSouthboundConfig struct {
+	Address string
+}
+
+type NorthboundConfig struct {
+	Endpoint    string
+	TopicPrefix string
+}
+
+type ClientsConfig struct {
+	MaxParallel    int
+	RequestTimeout time.Duration
+}
+
+type SchedulerConfig struct {
+	PollInterval time.Duration
+	MaxJitter    time.Duration
+}
+
+type AddressGuardConfig struct {
+	Enabled          bool
+	AllowedAddresses []uint8
+	BlockedAddresses []uint8
+}
+
+type EmulationConfig struct {
+	Enabled                bool
+	VirtualSourceAddresses []uint8
+}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -1,0 +1,403 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ValidationError struct {
+	Code    string
+	Field   string
+	Message string
+}
+
+type ValidationErrors []ValidationError
+
+func (errors ValidationErrors) Error() string {
+	formatted := make([]string, 0, len(errors))
+
+	for _, validationError := range errors {
+		formatted = append(
+			formatted,
+			fmt.Sprintf(
+				"%s (%s): %s",
+				validationError.Code,
+				validationError.Field,
+				validationError.Message,
+			),
+		)
+	}
+
+	return "config validation failed: " + strings.Join(formatted, "; ")
+}
+
+func Validate(configuration Config) error {
+	return configuration.Validate()
+}
+
+func (configuration Config) Validate() error {
+	validationErrors := make(ValidationErrors, 0)
+
+	validationErrors = append(
+		validationErrors,
+		validateSouthbound(configuration.Southbound)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateNorthbound(configuration.Northbound)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateClients(configuration.Clients)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateScheduler(configuration.Scheduler)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateAddressGuard(configuration.AddressGuard)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateEmulation(configuration.Emulation)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateEmulationAddressGuardCompatibility(
+			configuration.Emulation,
+			configuration.AddressGuard,
+		)...,
+	)
+
+	if len(validationErrors) == 0 {
+		return nil
+	}
+
+	return validationErrors
+}
+
+func validateSouthbound(configuration SouthboundConfig) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	switch configuration.Transport {
+	case SouthboundTransportSerial:
+		if strings.TrimSpace(configuration.Serial.Device) == "" {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "southbound.serial.device.required",
+				Field:   "southbound.serial.device",
+				Message: "serial device is required",
+			})
+		}
+
+		if configuration.Serial.BaudRate <= 0 {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "southbound.serial.baud_rate.invalid",
+				Field:   "southbound.serial.baud_rate",
+				Message: "baud rate must be greater than zero",
+			})
+		}
+
+		if strings.TrimSpace(configuration.TCP.Address) != "" {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "southbound.tcp.address.conflict",
+				Field:   "southbound.tcp.address",
+				Message: "tcp address must be empty when transport is serial",
+			})
+		}
+	case SouthboundTransportTCP:
+		if strings.TrimSpace(configuration.TCP.Address) == "" {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "southbound.tcp.address.required",
+				Field:   "southbound.tcp.address",
+				Message: "tcp address is required",
+			})
+		}
+
+		if strings.TrimSpace(configuration.Serial.Device) != "" {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "southbound.serial.device.conflict",
+				Field:   "southbound.serial.device",
+				Message: "serial device must be empty when transport is tcp",
+			})
+		}
+
+		if configuration.Serial.BaudRate != 0 {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "southbound.serial.baud_rate.conflict",
+				Field:   "southbound.serial.baud_rate",
+				Message: "baud rate must be zero when transport is tcp",
+			})
+		}
+	default:
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "southbound.transport.invalid",
+			Field:   "southbound.transport",
+			Message: "transport must be either serial or tcp",
+		})
+	}
+
+	return validationErrors
+}
+
+func validateNorthbound(configuration NorthboundConfig) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	if strings.TrimSpace(configuration.Endpoint) == "" {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "northbound.endpoint.required",
+			Field:   "northbound.endpoint",
+			Message: "endpoint is required",
+		})
+	}
+
+	return validationErrors
+}
+
+func validateClients(configuration ClientsConfig) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	if configuration.MaxParallel <= 0 {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "clients.max_parallel.invalid",
+			Field:   "clients.max_parallel",
+			Message: "max parallel must be greater than zero",
+		})
+	}
+
+	if configuration.RequestTimeout <= 0 {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "clients.request_timeout.invalid",
+			Field:   "clients.request_timeout",
+			Message: "request timeout must be greater than zero",
+		})
+	}
+
+	return validationErrors
+}
+
+func validateScheduler(configuration SchedulerConfig) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	if configuration.PollInterval <= 0 {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "scheduler.poll_interval.invalid",
+			Field:   "scheduler.poll_interval",
+			Message: "poll interval must be greater than zero",
+		})
+	}
+
+	if configuration.MaxJitter < 0 {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "scheduler.max_jitter.invalid",
+			Field:   "scheduler.max_jitter",
+			Message: "max jitter cannot be negative",
+		})
+	}
+
+	if configuration.PollInterval > 0 && configuration.MaxJitter >= configuration.PollInterval {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "scheduler.max_jitter.out_of_range",
+			Field:   "scheduler.max_jitter",
+			Message: "max jitter must be lower than poll interval",
+		})
+	}
+
+	return validationErrors
+}
+
+func validateAddressGuard(configuration AddressGuardConfig) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	if !configuration.Enabled {
+		if len(configuration.AllowedAddresses) > 0 {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "address_guard.allowed_addresses.forbidden",
+				Field:   "address_guard.allowed_addresses",
+				Message: "allowed addresses must be empty when address guard is disabled",
+			})
+		}
+
+		if len(configuration.BlockedAddresses) > 0 {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "address_guard.blocked_addresses.forbidden",
+				Field:   "address_guard.blocked_addresses",
+				Message: "blocked addresses must be empty when address guard is disabled",
+			})
+		}
+
+		return validationErrors
+	}
+
+	if len(configuration.AllowedAddresses) == 0 && len(configuration.BlockedAddresses) == 0 {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "address_guard.policy.required",
+			Field:   "address_guard",
+			Message: "at least one address policy must be configured when address guard is enabled",
+		})
+	}
+
+	validationErrors = append(
+		validationErrors,
+		validateAddressList("address_guard.allowed_addresses", configuration.AllowedAddresses)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateAddressList("address_guard.blocked_addresses", configuration.BlockedAddresses)...,
+	)
+
+	blockedAddressSet := buildAddressSet(configuration.BlockedAddresses)
+	overlapAddressSet := make(map[uint8]struct{})
+
+	for _, allowedAddress := range configuration.AllowedAddresses {
+		if _, blocked := blockedAddressSet[allowedAddress]; !blocked {
+			continue
+		}
+
+		if _, alreadyReported := overlapAddressSet[allowedAddress]; alreadyReported {
+			continue
+		}
+
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "address_guard.address.overlap",
+			Field:   "address_guard",
+			Message: fmt.Sprintf("address 0x%02X cannot be both allowed and blocked", allowedAddress),
+		})
+		overlapAddressSet[allowedAddress] = struct{}{}
+	}
+
+	return validationErrors
+}
+
+func validateEmulation(configuration EmulationConfig) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	if !configuration.Enabled {
+		if len(configuration.VirtualSourceAddresses) > 0 {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "emulation.virtual_source_addresses.forbidden",
+				Field:   "emulation.virtual_source_addresses",
+				Message: "virtual source addresses must be empty when emulation is disabled",
+			})
+		}
+
+		return validationErrors
+	}
+
+	if len(configuration.VirtualSourceAddresses) == 0 {
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "emulation.virtual_source_addresses.required",
+			Field:   "emulation.virtual_source_addresses",
+			Message: "at least one virtual source address is required when emulation is enabled",
+		})
+	}
+
+	validationErrors = append(
+		validationErrors,
+		validateAddressList("emulation.virtual_source_addresses", configuration.VirtualSourceAddresses)...,
+	)
+
+	return validationErrors
+}
+
+func validateEmulationAddressGuardCompatibility(
+	emulationConfiguration EmulationConfig,
+	addressGuardConfiguration AddressGuardConfig,
+) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	if !emulationConfiguration.Enabled || !addressGuardConfiguration.Enabled {
+		return validationErrors
+	}
+
+	uniqueVirtualAddresses := uniqueAddressesInOrder(
+		emulationConfiguration.VirtualSourceAddresses,
+	)
+	blockedAddressSet := buildAddressSet(addressGuardConfiguration.BlockedAddresses)
+
+	for _, virtualAddress := range uniqueVirtualAddresses {
+		if _, blocked := blockedAddressSet[virtualAddress]; !blocked {
+			continue
+		}
+
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "emulation.virtual_source_addresses.blocked",
+			Field:   "emulation.virtual_source_addresses",
+			Message: fmt.Sprintf("virtual source address 0x%02X is blocked by address guard", virtualAddress),
+		})
+	}
+
+	if len(addressGuardConfiguration.AllowedAddresses) == 0 {
+		return validationErrors
+	}
+
+	allowedAddressSet := buildAddressSet(addressGuardConfiguration.AllowedAddresses)
+
+	for _, virtualAddress := range uniqueVirtualAddresses {
+		if _, allowed := allowedAddressSet[virtualAddress]; allowed {
+			continue
+		}
+
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "emulation.virtual_source_addresses.not_allowed",
+			Field:   "emulation.virtual_source_addresses",
+			Message: fmt.Sprintf("virtual source address 0x%02X is not allowed by address guard", virtualAddress),
+		})
+	}
+
+	return validationErrors
+}
+
+func validateAddressList(field string, addresses []uint8) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+	seenAddresses := make(map[uint8]struct{})
+
+	for index, address := range addresses {
+		if address == 0x00 || address == 0xFF {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "address.invalid_reserved",
+				Field:   fmt.Sprintf("%s[%d]", field, index),
+				Message: fmt.Sprintf("address 0x%02X is reserved", address),
+			})
+		}
+
+		if _, seen := seenAddresses[address]; seen {
+			validationErrors = append(validationErrors, ValidationError{
+				Code:    "address.duplicate",
+				Field:   fmt.Sprintf("%s[%d]", field, index),
+				Message: fmt.Sprintf("address 0x%02X is duplicated", address),
+			})
+			continue
+		}
+
+		seenAddresses[address] = struct{}{}
+	}
+
+	return validationErrors
+}
+
+func uniqueAddressesInOrder(addresses []uint8) []uint8 {
+	uniqueAddresses := make([]uint8, 0, len(addresses))
+	seenAddresses := make(map[uint8]struct{})
+
+	for _, address := range addresses {
+		if _, seen := seenAddresses[address]; seen {
+			continue
+		}
+
+		seenAddresses[address] = struct{}{}
+		uniqueAddresses = append(uniqueAddresses, address)
+	}
+
+	return uniqueAddresses
+}
+
+func buildAddressSet(addresses []uint8) map[uint8]struct{} {
+	addressSet := make(map[uint8]struct{}, len(addresses))
+
+	for _, address := range addresses {
+		addressSet[address] = struct{}{}
+	}
+
+	return addressSet
+}

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -1,0 +1,223 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestValidateAcceptsValidSerialConfiguration(t *testing.T) {
+	configuration := validConfiguration()
+
+	err := Validate(configuration)
+	if err != nil {
+		t.Fatalf("expected no validation errors, got %v", err)
+	}
+}
+
+func TestValidateAcceptsValidTCPConfiguration(t *testing.T) {
+	configuration := validConfiguration()
+	configuration.Southbound.Transport = SouthboundTransportTCP
+	configuration.Southbound.Serial = SerialSouthboundConfig{}
+	configuration.Southbound.TCP = TCPSouthboundConfig{
+		Address: "127.0.0.1:9000",
+	}
+
+	err := Validate(configuration)
+	if err != nil {
+		t.Fatalf("expected no validation errors, got %v", err)
+	}
+}
+
+func TestValidateReturnsDeterministicErrors(t *testing.T) {
+	configuration := Config{
+		Southbound: SouthboundConfig{
+			Transport: SouthboundTransportSerial,
+			Serial: SerialSouthboundConfig{
+				Device:   "",
+				BaudRate: 0,
+			},
+			TCP: TCPSouthboundConfig{
+				Address: "127.0.0.1:3333",
+			},
+		},
+		Northbound: NorthboundConfig{
+			Endpoint: "",
+		},
+		Clients: ClientsConfig{
+			MaxParallel:    0,
+			RequestTimeout: 0,
+		},
+		Scheduler: SchedulerConfig{
+			PollInterval: 0,
+			MaxJitter:    -time.Second,
+		},
+		AddressGuard: AddressGuardConfig{
+			Enabled:          true,
+			AllowedAddresses: []uint8{0x00, 0x21, 0x21, 0x30},
+			BlockedAddresses: []uint8{0x30, 0xFF},
+		},
+		Emulation: EmulationConfig{
+			Enabled:                true,
+			VirtualSourceAddresses: []uint8{0x40, 0x21, 0x30, 0x30},
+		},
+	}
+
+	expectedErrors := ValidationErrors{
+		{
+			Code:    "southbound.serial.device.required",
+			Field:   "southbound.serial.device",
+			Message: "serial device is required",
+		},
+		{
+			Code:    "southbound.serial.baud_rate.invalid",
+			Field:   "southbound.serial.baud_rate",
+			Message: "baud rate must be greater than zero",
+		},
+		{
+			Code:    "southbound.tcp.address.conflict",
+			Field:   "southbound.tcp.address",
+			Message: "tcp address must be empty when transport is serial",
+		},
+		{
+			Code:    "northbound.endpoint.required",
+			Field:   "northbound.endpoint",
+			Message: "endpoint is required",
+		},
+		{
+			Code:    "clients.max_parallel.invalid",
+			Field:   "clients.max_parallel",
+			Message: "max parallel must be greater than zero",
+		},
+		{
+			Code:    "clients.request_timeout.invalid",
+			Field:   "clients.request_timeout",
+			Message: "request timeout must be greater than zero",
+		},
+		{
+			Code:    "scheduler.poll_interval.invalid",
+			Field:   "scheduler.poll_interval",
+			Message: "poll interval must be greater than zero",
+		},
+		{
+			Code:    "scheduler.max_jitter.invalid",
+			Field:   "scheduler.max_jitter",
+			Message: "max jitter cannot be negative",
+		},
+		{
+			Code:    "address.invalid_reserved",
+			Field:   "address_guard.allowed_addresses[0]",
+			Message: "address 0x00 is reserved",
+		},
+		{
+			Code:    "address.duplicate",
+			Field:   "address_guard.allowed_addresses[2]",
+			Message: "address 0x21 is duplicated",
+		},
+		{
+			Code:    "address.invalid_reserved",
+			Field:   "address_guard.blocked_addresses[1]",
+			Message: "address 0xFF is reserved",
+		},
+		{
+			Code:    "address_guard.address.overlap",
+			Field:   "address_guard",
+			Message: "address 0x30 cannot be both allowed and blocked",
+		},
+		{
+			Code:    "address.duplicate",
+			Field:   "emulation.virtual_source_addresses[3]",
+			Message: "address 0x30 is duplicated",
+		},
+		{
+			Code:    "emulation.virtual_source_addresses.blocked",
+			Field:   "emulation.virtual_source_addresses",
+			Message: "virtual source address 0x30 is blocked by address guard",
+		},
+		{
+			Code:    "emulation.virtual_source_addresses.not_allowed",
+			Field:   "emulation.virtual_source_addresses",
+			Message: "virtual source address 0x40 is not allowed by address guard",
+		},
+	}
+
+	actualErrors, ok := Validate(configuration).(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors type")
+	}
+
+	if !reflect.DeepEqual(actualErrors, expectedErrors) {
+		t.Fatalf("unexpected validation errors:\nexpected: %#v\nactual: %#v", expectedErrors, actualErrors)
+	}
+
+	repeatedErrors, ok := Validate(configuration).(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors type")
+	}
+
+	if !reflect.DeepEqual(actualErrors, repeatedErrors) {
+		t.Fatalf("expected deterministic validation errors")
+	}
+}
+
+func TestValidateRejectsDisabledPoliciesWithData(t *testing.T) {
+	configuration := validConfiguration()
+	configuration.AddressGuard.Enabled = false
+	configuration.AddressGuard.AllowedAddresses = []uint8{0x21}
+	configuration.Emulation.Enabled = false
+	configuration.Emulation.VirtualSourceAddresses = []uint8{0x21}
+
+	expectedErrors := ValidationErrors{
+		{
+			Code:    "address_guard.allowed_addresses.forbidden",
+			Field:   "address_guard.allowed_addresses",
+			Message: "allowed addresses must be empty when address guard is disabled",
+		},
+		{
+			Code:    "emulation.virtual_source_addresses.forbidden",
+			Field:   "emulation.virtual_source_addresses",
+			Message: "virtual source addresses must be empty when emulation is disabled",
+		},
+	}
+
+	actualErrors, ok := Validate(configuration).(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors type")
+	}
+
+	if !reflect.DeepEqual(actualErrors, expectedErrors) {
+		t.Fatalf("unexpected validation errors:\nexpected: %#v\nactual: %#v", expectedErrors, actualErrors)
+	}
+}
+
+func validConfiguration() Config {
+	return Config{
+		Southbound: SouthboundConfig{
+			Transport: SouthboundTransportSerial,
+			Serial: SerialSouthboundConfig{
+				Device:   "/dev/ttyUSB0",
+				BaudRate: 9600,
+			},
+		},
+		Northbound: NorthboundConfig{
+			Endpoint:    "127.0.0.1:9001",
+			TopicPrefix: "helianthus",
+		},
+		Clients: ClientsConfig{
+			MaxParallel:    4,
+			RequestTimeout: 3 * time.Second,
+		},
+		Scheduler: SchedulerConfig{
+			PollInterval: 5 * time.Second,
+			MaxJitter:    1 * time.Second,
+		},
+		AddressGuard: AddressGuardConfig{
+			Enabled:          true,
+			AllowedAddresses: []uint8{0x21, 0x30},
+		},
+		Emulation: EmulationConfig{
+			Enabled:                true,
+			VirtualSourceAddresses: []uint8{0x21},
+		},
+	}
+}


### PR DESCRIPTION
Fixes #2

## Summary
- add `internal/config` schema covering southbound, northbound, clients, scheduler, address guard, and emulation
- add strict validator with deterministic, ordered validation errors and compatibility checks
- add positive and negative unit tests, including deterministic error ordering assertions

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/terminology-gate.sh`