### PR TITLE
M1: Southbound ENS driver

### DIFF
--- a/internal/southbound/ens/codec.go
+++ b/internal/southbound/ens/codec.go
@@ -1,0 +1,164 @@
+package ens
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+var ErrMalformedFrame = errors.New("ens malformed frame")
+
+type ENSCommand byte
+
+const (
+	ENSCommandData ENSCommand = 0x1
+)
+
+const (
+	ENSByteEscape = byte(0xA9)
+	ENSByteSync   = byte(0xAA)
+	ensEscEscape  = byte(0x00)
+	ensEscSync    = byte(0x01)
+)
+
+type ENSParser struct {
+	escapePending bool
+}
+
+func (parser *ENSParser) Reset() {
+	parser.escapePending = false
+}
+
+func (parser *ENSParser) Finish() error {
+	if !parser.escapePending {
+		return nil
+	}
+
+	parser.escapePending = false
+	return fmt.Errorf("%w: dangling escape byte", ErrMalformedFrame)
+}
+
+func (parser *ENSParser) Parse(reader io.Reader) (downstream.Frame, error) {
+	buffer := make([]byte, 1)
+
+	for {
+		if _, err := io.ReadFull(reader, buffer); err != nil {
+			return downstream.Frame{}, err
+		}
+
+		frame, complete, err := parser.Feed(buffer[0])
+		if err != nil {
+			return downstream.Frame{}, err
+		}
+
+		if complete {
+			return frame, nil
+		}
+	}
+}
+
+func (parser *ENSParser) Feed(payloadByte byte) (downstream.Frame, bool, error) {
+	if parser.escapePending {
+		parser.escapePending = false
+
+		switch payloadByte {
+		case ensEscEscape:
+			return frameFromENS(ENSByteEscape), true, nil
+		case ensEscSync:
+			return frameFromENS(ENSByteSync), true, nil
+		default:
+			return downstream.Frame{}, false, fmt.Errorf(
+				"%w: invalid escaped byte 0x%02X",
+				ErrMalformedFrame,
+				payloadByte,
+			)
+		}
+	}
+
+	if payloadByte == ENSByteEscape {
+		parser.escapePending = true
+		return downstream.Frame{}, false, nil
+	}
+
+	if payloadByte == ENSByteSync {
+		return downstream.Frame{}, false, fmt.Errorf(
+			"%w: unexpected sync byte 0x%02X",
+			ErrMalformedFrame,
+			payloadByte,
+		)
+	}
+
+	return frameFromENS(payloadByte), true, nil
+}
+
+type ENSEncoder struct{}
+
+func (ENSEncoder) Encode(frame downstream.Frame) ([]byte, error) {
+	if len(frame.Payload) != 1 {
+		return nil, fmt.Errorf(
+			"ens frame payload must contain exactly one data byte, got %d",
+			len(frame.Payload),
+		)
+	}
+
+	if frame.Command != 0 && frame.Command != byte(ENSCommandData) {
+		return nil, fmt.Errorf("ens command is not supported: 0x%02X", frame.Command)
+	}
+
+	return EncodeENS(frame.Payload), nil
+}
+
+func EncodeENS(data []byte) []byte {
+	if len(data) == 0 {
+		return nil
+	}
+
+	encoded := make([]byte, 0, len(data))
+	for _, payloadByte := range data {
+		switch payloadByte {
+		case ENSByteEscape:
+			encoded = append(encoded, ENSByteEscape, ensEscEscape)
+		case ENSByteSync:
+			encoded = append(encoded, ENSByteEscape, ensEscSync)
+		default:
+			encoded = append(encoded, payloadByte)
+		}
+	}
+
+	return encoded
+}
+
+func DecodeENS(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	parser := &ENSParser{}
+	decoded := make([]byte, 0, len(data))
+
+	for _, payloadByte := range data {
+		frame, complete, err := parser.Feed(payloadByte)
+		if err != nil {
+			return nil, err
+		}
+
+		if complete {
+			decoded = append(decoded, frame.Payload[0])
+		}
+	}
+
+	if err := parser.Finish(); err != nil {
+		return nil, err
+	}
+
+	return decoded, nil
+}
+
+func frameFromENS(data byte) downstream.Frame {
+	return downstream.Frame{
+		Command: byte(ENSCommandData),
+		Payload: []byte{data},
+	}
+}

--- a/internal/southbound/ens/codec_test.go
+++ b/internal/southbound/ens/codec_test.go
@@ -1,0 +1,157 @@
+package ens
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+func TestENSEncoderEscapesSpecialBytes(t *testing.T) {
+	encoder := ENSEncoder{}
+
+	testCases := []struct {
+		name        string
+		frame       downstream.Frame
+		expectedRaw []byte
+	}{
+		{
+			name: "escape_byte",
+			frame: downstream.Frame{
+				Command: byte(ENSCommandData),
+				Payload: []byte{ENSByteEscape},
+			},
+			expectedRaw: []byte{ENSByteEscape, ensEscEscape},
+		},
+		{
+			name: "sync_byte",
+			frame: downstream.Frame{
+				Command: byte(ENSCommandData),
+				Payload: []byte{ENSByteSync},
+			},
+			expectedRaw: []byte{ENSByteEscape, ensEscSync},
+		},
+		{
+			name: "regular_byte",
+			frame: downstream.Frame{
+				Command: byte(ENSCommandData),
+				Payload: []byte{0x42},
+			},
+			expectedRaw: []byte{0x42},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			encoded, err := encoder.Encode(testCase.frame)
+			if err != nil {
+				t.Fatalf("expected encode success, got %v", err)
+			}
+
+			if !reflect.DeepEqual(encoded, testCase.expectedRaw) {
+				t.Fatalf("expected encoded bytes %#v, got %#v", testCase.expectedRaw, encoded)
+			}
+		})
+	}
+}
+
+func TestENSParserUnescapesBytes(t *testing.T) {
+	parser := &ENSParser{}
+
+	testCases := []struct {
+		name         string
+		input        []byte
+		expectedByte byte
+	}{
+		{
+			name:         "escaped_escape",
+			input:        []byte{ENSByteEscape, ensEscEscape},
+			expectedByte: ENSByteEscape,
+		},
+		{
+			name:         "escaped_sync",
+			input:        []byte{ENSByteEscape, ensEscSync},
+			expectedByte: ENSByteSync,
+		},
+		{
+			name:         "raw_byte",
+			input:        []byte{0x31},
+			expectedByte: 0x31,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			frame, err := parser.Parse(bytes.NewReader(testCase.input))
+			if err != nil {
+				t.Fatalf("expected parse success, got %v", err)
+			}
+
+			expectedFrame := downstream.Frame{
+				Command: byte(ENSCommandData),
+				Payload: []byte{testCase.expectedByte},
+			}
+			if !reflect.DeepEqual(frame, expectedFrame) {
+				t.Fatalf("expected frame %#v, got %#v", expectedFrame, frame)
+			}
+		})
+	}
+}
+
+func TestENSParserKeepsStateAcrossChunkBoundaries(t *testing.T) {
+	parser := &ENSParser{}
+
+	_, err := parser.Parse(bytes.NewReader([]byte{ENSByteEscape}))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected EOF for incomplete escape sequence, got %v", err)
+	}
+
+	frame, err := parser.Parse(bytes.NewReader([]byte{ensEscSync}))
+	if err != nil {
+		t.Fatalf("expected parse success on continuation chunk, got %v", err)
+	}
+
+	expectedFrame := downstream.Frame{
+		Command: byte(ENSCommandData),
+		Payload: []byte{ENSByteSync},
+	}
+	if !reflect.DeepEqual(frame, expectedFrame) {
+		t.Fatalf("expected reconstructed frame %#v, got %#v", expectedFrame, frame)
+	}
+}
+
+func TestENSParserRecoversAfterMalformedEscapeSequence(t *testing.T) {
+	parser := &ENSParser{}
+	stream := bytes.NewReader([]byte{
+		ENSByteEscape, 0x02,
+		0x41,
+	})
+
+	_, err := parser.Parse(stream)
+	if !errors.Is(err, ErrMalformedFrame) {
+		t.Fatalf("expected malformed frame error, got %v", err)
+	}
+
+	frame, err := parser.Parse(stream)
+	if err != nil {
+		t.Fatalf("expected parser recovery success, got %v", err)
+	}
+
+	expectedFrame := downstream.Frame{
+		Command: byte(ENSCommandData),
+		Payload: []byte{0x41},
+	}
+	if !reflect.DeepEqual(frame, expectedFrame) {
+		t.Fatalf("expected recovered frame %#v, got %#v", expectedFrame, frame)
+	}
+}
+
+func TestDecodeENSRejectsDanglingEscape(t *testing.T) {
+	_, err := DecodeENS([]byte{ENSByteEscape})
+	if !errors.Is(err, ErrMalformedFrame) {
+		t.Fatalf("expected malformed frame error, got %v", err)
+	}
+}

--- a/internal/southbound/ens/driver.go
+++ b/internal/southbound/ens/driver.go
@@ -1,0 +1,351 @@
+package ens
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+var (
+	ErrDialTimeout  = errors.New("ens dial timeout")
+	ErrReadTimeout  = errors.New("ens read timeout")
+	ErrWriteTimeout = errors.New("ens write timeout")
+)
+
+type Connection interface {
+	io.ReadWriteCloser
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+}
+
+type Dialer interface {
+	DialContext(context.Context) (Connection, error)
+}
+
+type Parser interface {
+	Parse(io.Reader) (downstream.Frame, error)
+}
+
+type Encoder interface {
+	Encode(downstream.Frame) ([]byte, error)
+}
+
+type Hooks struct {
+	OnConnect    func()
+	OnDisconnect func(error)
+	OnReconnect  func(attempt int, cause error)
+}
+
+type Options struct {
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+}
+
+type Driver struct {
+	mutex             sync.Mutex
+	dialer            Dialer
+	parser            Parser
+	encoder           Encoder
+	options           Options
+	hooks             Hooks
+	connection        Connection
+	reconnectAttempts int
+}
+
+type NetDialer struct {
+	Network string
+	Address string
+	Dialer  *net.Dialer
+}
+
+func (dialer NetDialer) DialContext(ctx context.Context) (Connection, error) {
+	network := dialer.Network
+	if network == "" {
+		network = "tcp"
+	}
+
+	baseDialer := dialer.Dialer
+	if baseDialer == nil {
+		baseDialer = &net.Dialer{}
+	}
+
+	connection, err := baseDialer.DialContext(ctx, network, dialer.Address)
+	if err != nil {
+		return nil, err
+	}
+
+	return connection, nil
+}
+
+func NewDriver(
+	dialer Dialer,
+	parser Parser,
+	encoder Encoder,
+	options Options,
+	hooks Hooks,
+) (*Driver, error) {
+	if dialer == nil {
+		return nil, errors.New("dialer is required")
+	}
+
+	if parser == nil {
+		return nil, errors.New("parser is required")
+	}
+
+	if encoder == nil {
+		return nil, errors.New("encoder is required")
+	}
+
+	return &Driver{
+		dialer:  dialer,
+		parser:  parser,
+		encoder: encoder,
+		options: options,
+		hooks:   hooks,
+	}, nil
+}
+
+func (driver *Driver) Read() (downstream.Frame, error) {
+	driver.mutex.Lock()
+	defer driver.mutex.Unlock()
+
+	frame, err := driver.readLocked()
+	if err == nil {
+		return frame, nil
+	}
+
+	if !driver.shouldReconnect(err) {
+		return downstream.Frame{}, err
+	}
+
+	if reconnectErr := driver.reconnectLocked(err); reconnectErr != nil {
+		return downstream.Frame{}, reconnectErr
+	}
+
+	return driver.readLocked()
+}
+
+func (driver *Driver) Write(frame downstream.Frame) error {
+	driver.mutex.Lock()
+	defer driver.mutex.Unlock()
+
+	err := driver.writeLocked(frame)
+	if err == nil {
+		return nil
+	}
+
+	if !driver.shouldReconnect(err) {
+		return err
+	}
+
+	if reconnectErr := driver.reconnectLocked(err); reconnectErr != nil {
+		return reconnectErr
+	}
+
+	return driver.writeLocked(frame)
+}
+
+func (driver *Driver) Close() error {
+	driver.mutex.Lock()
+	defer driver.mutex.Unlock()
+
+	return driver.closeLocked(nil)
+}
+
+func (driver *Driver) readLocked() (downstream.Frame, error) {
+	connection, err := driver.ensureConnectedLocked()
+	if err != nil {
+		return downstream.Frame{}, err
+	}
+
+	if err := setReadDeadline(connection, driver.options.ReadTimeout); err != nil {
+		return downstream.Frame{}, err
+	}
+
+	frame, err := driver.parser.Parse(connection)
+	if err != nil {
+		if isTimeoutError(err) {
+			return downstream.Frame{}, wrapError(ErrReadTimeout, err)
+		}
+
+		return downstream.Frame{}, err
+	}
+
+	return frame, nil
+}
+
+func (driver *Driver) writeLocked(frame downstream.Frame) error {
+	connection, err := driver.ensureConnectedLocked()
+	if err != nil {
+		return err
+	}
+
+	payload, err := driver.encoder.Encode(frame)
+	if err != nil {
+		return err
+	}
+
+	if err := setWriteDeadline(connection, driver.options.WriteTimeout); err != nil {
+		return err
+	}
+
+	if err := writeAll(connection, payload); err != nil {
+		if isTimeoutError(err) {
+			return wrapError(ErrWriteTimeout, err)
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (driver *Driver) ensureConnectedLocked() (Connection, error) {
+	if driver.connection != nil {
+		return driver.connection, nil
+	}
+
+	ctx := context.Background()
+	cancel := func() {}
+
+	if driver.options.DialTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, driver.options.DialTimeout)
+	}
+	defer cancel()
+
+	connection, err := driver.dialer.DialContext(ctx)
+	if err != nil {
+		if isTimeoutError(err) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, wrapError(ErrDialTimeout, err)
+		}
+
+		return nil, err
+	}
+
+	driver.connection = connection
+	callHook(driver.hooks.OnConnect)
+
+	return connection, nil
+}
+
+func (driver *Driver) reconnectLocked(cause error) error {
+	if err := driver.closeLocked(cause); err != nil {
+		return err
+	}
+
+	driver.reconnectAttempts++
+	if driver.hooks.OnReconnect != nil {
+		driver.hooks.OnReconnect(driver.reconnectAttempts, cause)
+	}
+
+	_, err := driver.ensureConnectedLocked()
+	return err
+}
+
+func (driver *Driver) closeLocked(cause error) error {
+	if driver.connection == nil {
+		return nil
+	}
+
+	connection := driver.connection
+	driver.connection = nil
+
+	callHookWithError(driver.hooks.OnDisconnect, cause)
+
+	if err := connection.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (driver *Driver) shouldReconnect(err error) bool {
+	switch {
+	case err == nil:
+		return false
+	case errors.Is(err, ErrReadTimeout):
+		return false
+	case errors.Is(err, ErrWriteTimeout):
+		return false
+	case errors.Is(err, ErrDialTimeout):
+		return false
+	case errors.Is(err, ErrMalformedFrame):
+		return false
+	case errors.Is(err, io.EOF):
+		return true
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return true
+	case errors.Is(err, net.ErrClosed):
+		return true
+	}
+
+	var netError net.Error
+	if errors.As(err, &netError) {
+		return !netError.Timeout()
+	}
+
+	return false
+}
+
+func setReadDeadline(connection Connection, timeout time.Duration) error {
+	if timeout <= 0 {
+		return connection.SetReadDeadline(time.Time{})
+	}
+
+	return connection.SetReadDeadline(time.Now().Add(timeout))
+}
+
+func setWriteDeadline(connection Connection, timeout time.Duration) error {
+	if timeout <= 0 {
+		return connection.SetWriteDeadline(time.Time{})
+	}
+
+	return connection.SetWriteDeadline(time.Now().Add(timeout))
+}
+
+func writeAll(writer io.Writer, payload []byte) error {
+	remaining := payload
+
+	for len(remaining) > 0 {
+		written, err := writer.Write(remaining)
+		if err != nil {
+			return err
+		}
+
+		remaining = remaining[written:]
+	}
+
+	return nil
+}
+
+func wrapError(base error, err error) error {
+	return fmt.Errorf("%w: %v", base, err)
+}
+
+func isTimeoutError(err error) bool {
+	var netError net.Error
+	if errors.As(err, &netError) {
+		return netError.Timeout()
+	}
+
+	return false
+}
+
+func callHook(hook func()) {
+	if hook != nil {
+		hook()
+	}
+}
+
+func callHookWithError(hook func(error), err error) {
+	if hook != nil {
+		hook(err)
+	}
+}

--- a/internal/southbound/ens/driver_test.go
+++ b/internal/southbound/ens/driver_test.go
@@ -1,0 +1,437 @@
+package ens
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+func TestDriverReadWriteLifecycle(t *testing.T) {
+	parser := &ENSParser{}
+	encoder := ENSEncoder{}
+	connection := &stubConnection{
+		readSteps: []readStep{
+			{payload: []byte{ENSByteEscape, ensEscEscape}},
+		},
+	}
+	dialer := &stubDialer{
+		connections: []Connection{connection},
+	}
+
+	connectCalls := 0
+	driver, err := NewDriver(
+		dialer,
+		parser,
+		encoder,
+		Options{
+			ReadTimeout:  time.Second,
+			WriteTimeout: time.Second,
+		},
+		Hooks{
+			OnConnect: func() {
+				connectCalls++
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected driver creation success, got %v", err)
+	}
+
+	frame, err := driver.Read()
+	if err != nil {
+		t.Fatalf("expected read success, got %v", err)
+	}
+
+	expectedReadFrame := downstream.Frame{
+		Command: byte(ENSCommandData),
+		Payload: []byte{ENSByteEscape},
+	}
+	if !reflect.DeepEqual(frame, expectedReadFrame) {
+		t.Fatalf("expected frame %#v, got %#v", expectedReadFrame, frame)
+	}
+
+	err = driver.Write(downstream.Frame{
+		Command: byte(ENSCommandData),
+		Payload: []byte{ENSByteSync},
+	})
+	if err != nil {
+		t.Fatalf("expected write success, got %v", err)
+	}
+
+	if dialer.calls != 1 {
+		t.Fatalf("expected one dial call, got %d", dialer.calls)
+	}
+
+	if connectCalls != 1 {
+		t.Fatalf("expected one connect hook call, got %d", connectCalls)
+	}
+
+	if len(connection.writes) != 1 {
+		t.Fatalf("expected one write call, got %d", len(connection.writes))
+	}
+
+	expectedWrite := []byte{ENSByteEscape, ensEscSync}
+	if !reflect.DeepEqual(connection.writes[0], expectedWrite) {
+		t.Fatalf("expected write %#v, got %#v", expectedWrite, connection.writes[0])
+	}
+
+	if connection.readDeadlineCalls != 1 {
+		t.Fatalf("expected one read deadline call, got %d", connection.readDeadlineCalls)
+	}
+
+	if connection.writeDeadlineCalls != 1 {
+		t.Fatalf("expected one write deadline call, got %d", connection.writeDeadlineCalls)
+	}
+}
+
+func TestDriverMapsTimeouts(t *testing.T) {
+	t.Run("read_timeout", func(t *testing.T) {
+		timeoutErr := timeoutNetworkError{message: "read timeout"}
+		driver, err := NewDriver(
+			&stubDialer{
+				connections: []Connection{
+					&stubConnection{
+						readSteps: []readStep{
+							{err: timeoutErr},
+						},
+					},
+				},
+			},
+			&ENSParser{},
+			ENSEncoder{},
+			Options{ReadTimeout: time.Second},
+			Hooks{},
+		)
+		if err != nil {
+			t.Fatalf("expected driver creation success, got %v", err)
+		}
+
+		_, err = driver.Read()
+		if !errors.Is(err, ErrReadTimeout) {
+			t.Fatalf("expected read timeout error, got %v", err)
+		}
+	})
+
+	t.Run("write_timeout", func(t *testing.T) {
+		timeoutErr := timeoutNetworkError{message: "write timeout"}
+		connection := &stubConnection{
+			writeErr: timeoutErr,
+		}
+		dialer := &stubDialer{
+			connections: []Connection{connection},
+		}
+		reconnectCalls := 0
+		driver, err := NewDriver(
+			dialer,
+			&ENSParser{},
+			ENSEncoder{},
+			Options{WriteTimeout: time.Second},
+			Hooks{
+				OnReconnect: func(int, error) {
+					reconnectCalls++
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("expected driver creation success, got %v", err)
+		}
+
+		err = driver.Write(downstream.Frame{
+			Command: byte(ENSCommandData),
+			Payload: []byte{0x20},
+		})
+		if !errors.Is(err, ErrWriteTimeout) {
+			t.Fatalf("expected write timeout error, got %v", err)
+		}
+
+		if reconnectCalls != 0 {
+			t.Fatalf("expected no reconnect attempts, got %d", reconnectCalls)
+		}
+	})
+
+	t.Run("dial_timeout", func(t *testing.T) {
+		timeoutErr := timeoutNetworkError{message: "dial timeout"}
+		driver, err := NewDriver(
+			&stubDialer{
+				errors: []error{timeoutErr},
+			},
+			&ENSParser{},
+			ENSEncoder{},
+			Options{DialTimeout: time.Second},
+			Hooks{},
+		)
+		if err != nil {
+			t.Fatalf("expected driver creation success, got %v", err)
+		}
+
+		_, err = driver.Read()
+		if !errors.Is(err, ErrDialTimeout) {
+			t.Fatalf("expected dial timeout error, got %v", err)
+		}
+	})
+}
+
+func TestDriverReconnectsAfterReadEOF(t *testing.T) {
+	firstConnection := &stubConnection{
+		readSteps: []readStep{
+			{err: io.EOF},
+		},
+	}
+	secondConnection := &stubConnection{
+		readSteps: []readStep{
+			{payload: []byte{0x44}},
+		},
+	}
+	dialer := &stubDialer{
+		connections: []Connection{
+			firstConnection,
+			secondConnection,
+		},
+	}
+
+	connectCalls := 0
+	disconnectCauses := make([]error, 0)
+	reconnectAttempts := make([]int, 0)
+
+	driver, err := NewDriver(
+		dialer,
+		&ENSParser{},
+		ENSEncoder{},
+		Options{},
+		Hooks{
+			OnConnect: func() {
+				connectCalls++
+			},
+			OnDisconnect: func(err error) {
+				disconnectCauses = append(disconnectCauses, err)
+			},
+			OnReconnect: func(attempt int, cause error) {
+				reconnectAttempts = append(reconnectAttempts, attempt)
+				if !errors.Is(cause, io.EOF) {
+					t.Fatalf("expected io.EOF reconnect cause, got %v", cause)
+				}
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected driver creation success, got %v", err)
+	}
+
+	frame, err := driver.Read()
+	if err != nil {
+		t.Fatalf("expected read success after reconnect, got %v", err)
+	}
+
+	expectedFrame := downstream.Frame{
+		Command: byte(ENSCommandData),
+		Payload: []byte{0x44},
+	}
+	if !reflect.DeepEqual(frame, expectedFrame) {
+		t.Fatalf("expected frame %#v, got %#v", expectedFrame, frame)
+	}
+
+	if dialer.calls != 2 {
+		t.Fatalf("expected two dial calls, got %d", dialer.calls)
+	}
+
+	if firstConnection.closeCalls != 1 {
+		t.Fatalf("expected first connection close call, got %d", firstConnection.closeCalls)
+	}
+
+	if connectCalls != 2 {
+		t.Fatalf("expected two connect hook calls, got %d", connectCalls)
+	}
+
+	if len(disconnectCauses) != 1 {
+		t.Fatalf("expected one disconnect hook call, got %d", len(disconnectCauses))
+	}
+
+	if !errors.Is(disconnectCauses[0], io.EOF) {
+		t.Fatalf("expected disconnect cause io.EOF, got %v", disconnectCauses[0])
+	}
+
+	if !reflect.DeepEqual(reconnectAttempts, []int{1}) {
+		t.Fatalf("expected reconnect attempts [1], got %v", reconnectAttempts)
+	}
+}
+
+func TestDriverMalformedDataDoesNotReconnect(t *testing.T) {
+	connection := &stubConnection{
+		readSteps: []readStep{
+			{payload: []byte{ENSByteEscape, 0x02}},
+		},
+	}
+	dialer := &stubDialer{
+		connections: []Connection{
+			connection,
+			&stubConnection{},
+		},
+	}
+	reconnectCalls := 0
+
+	driver, err := NewDriver(
+		dialer,
+		&ENSParser{},
+		ENSEncoder{},
+		Options{},
+		Hooks{
+			OnReconnect: func(int, error) {
+				reconnectCalls++
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected driver creation success, got %v", err)
+	}
+
+	_, err = driver.Read()
+	if !errors.Is(err, ErrMalformedFrame) {
+		t.Fatalf("expected malformed frame error, got %v", err)
+	}
+
+	if dialer.calls != 1 {
+		t.Fatalf("expected one dial call, got %d", dialer.calls)
+	}
+
+	if reconnectCalls != 0 {
+		t.Fatalf("expected no reconnect hook calls, got %d", reconnectCalls)
+	}
+
+	if connection.closeCalls != 0 {
+		t.Fatalf("expected no connection close calls, got %d", connection.closeCalls)
+	}
+}
+
+func TestNewDriverRequiresDependencies(t *testing.T) {
+	_, err := NewDriver(nil, &ENSParser{}, ENSEncoder{}, Options{}, Hooks{})
+	if err == nil {
+		t.Fatalf("expected dialer required error")
+	}
+
+	_, err = NewDriver(&stubDialer{}, nil, ENSEncoder{}, Options{}, Hooks{})
+	if err == nil {
+		t.Fatalf("expected parser required error")
+	}
+
+	_, err = NewDriver(&stubDialer{}, &ENSParser{}, nil, Options{}, Hooks{})
+	if err == nil {
+		t.Fatalf("expected encoder required error")
+	}
+}
+
+type stubDialer struct {
+	connections []Connection
+	errors      []error
+	calls       int
+}
+
+func (dialer *stubDialer) DialContext(context.Context) (Connection, error) {
+	callIndex := dialer.calls
+	dialer.calls++
+
+	if callIndex < len(dialer.errors) && dialer.errors[callIndex] != nil {
+		return nil, dialer.errors[callIndex]
+	}
+
+	if callIndex >= len(dialer.connections) {
+		return nil, errors.New("no connection available")
+	}
+
+	return dialer.connections[callIndex], nil
+}
+
+type readStep struct {
+	payload []byte
+	err     error
+}
+
+type stubConnection struct {
+	readSteps []readStep
+	readIndex int
+	readQueue []byte
+
+	writeErr error
+	writes   [][]byte
+
+	closeCalls         int
+	readDeadlineCalls  int
+	writeDeadlineCalls int
+	lastReadDeadline   time.Time
+	lastWriteDeadline  time.Time
+}
+
+func (connection *stubConnection) Read(buffer []byte) (int, error) {
+	for {
+		if len(connection.readQueue) > 0 {
+			written := copy(buffer, connection.readQueue)
+			connection.readQueue = connection.readQueue[written:]
+			return written, nil
+		}
+
+		if connection.readIndex >= len(connection.readSteps) {
+			return 0, io.EOF
+		}
+
+		step := connection.readSteps[connection.readIndex]
+		connection.readIndex++
+
+		if len(step.payload) > 0 {
+			connection.readQueue = append(connection.readQueue, step.payload...)
+			continue
+		}
+
+		if step.err != nil {
+			return 0, step.err
+		}
+	}
+}
+
+func (connection *stubConnection) Write(payload []byte) (int, error) {
+	if connection.writeErr != nil {
+		return 0, connection.writeErr
+	}
+
+	connection.writes = append(connection.writes, append([]byte(nil), payload...))
+	return len(payload), nil
+}
+
+func (connection *stubConnection) Close() error {
+	connection.closeCalls++
+	return nil
+}
+
+func (connection *stubConnection) SetReadDeadline(deadline time.Time) error {
+	connection.readDeadlineCalls++
+	connection.lastReadDeadline = deadline
+	return nil
+}
+
+func (connection *stubConnection) SetWriteDeadline(deadline time.Time) error {
+	connection.writeDeadlineCalls++
+	connection.lastWriteDeadline = deadline
+	return nil
+}
+
+type timeoutNetworkError struct {
+	message string
+}
+
+func (err timeoutNetworkError) Error() string {
+	return err.message
+}
+
+func (timeoutNetworkError) Timeout() bool {
+	return true
+}
+
+func (timeoutNetworkError) Temporary() bool {
+	return true
+}
+
+var _ net.Error = timeoutNetworkError{}


### PR DESCRIPTION
Fixes #5

## Summary
- add ENS codec with escape/unescape framing semantics and incremental parser recovery
- add ENS driver with dial/read/write lifecycle, timeout mapping, reconnect hooks, and recoverable reconnect behavior
- keep driver API aligned with ENH driver (`NewDriver`, `Options`, `Hooks`, `Read`, `Write`, `Close`)
- add focused codec and driver tests for framing, timeouts, reconnect, and malformed data handling

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/terminology-gate.sh`