### PR TITLE
M1: Northbound ENS multi-session listener

### DIFF
--- a/internal/northbound/ens/listener.go
+++ b/internal/northbound/ens/listener.go
@@ -1,0 +1,335 @@
+package ens
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundens "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/ens"
+)
+
+type Parser interface {
+	Parse(io.Reader) (downstream.Frame, error)
+}
+
+type ParserFactory func() Parser
+
+type FrameHandler func(context.Context, SessionInfo, downstream.Frame) error
+
+type Hooks struct {
+	OnConnect    func(SessionInfo)
+	OnDisconnect func(SessionInfo, error)
+	OnError      func(SessionInfo, error)
+}
+
+type Options struct {
+	ReadTimeout   time.Duration
+	ParserFactory ParserFactory
+}
+
+type SessionInfo struct {
+	ID          uint64
+	RemoteAddr  string
+	ConnectedAt time.Time
+}
+
+type Metrics struct {
+	ActiveSessions   int
+	TotalConnections uint64
+	TotalDisconnects uint64
+	TotalErrors      uint64
+	TotalFrames      uint64
+}
+
+type Listener struct {
+	listener net.Listener
+	handler  FrameHandler
+	hooks    Hooks
+	options  Options
+
+	mutex         sync.Mutex
+	sessions      map[uint64]sessionState
+	nextSessionID uint64
+	metrics       Metrics
+	closed        bool
+
+	waitGroup sync.WaitGroup
+	closeOnce sync.Once
+}
+
+type sessionState struct {
+	info SessionInfo
+	conn net.Conn
+}
+
+func NewListener(
+	listener net.Listener,
+	handler FrameHandler,
+	options Options,
+	hooks Hooks,
+) (*Listener, error) {
+	if listener == nil {
+		return nil, errors.New("listener is required")
+	}
+
+	if options.ParserFactory == nil {
+		options.ParserFactory = func() Parser {
+			return &southboundens.ENSParser{}
+		}
+	}
+
+	if handler == nil {
+		handler = func(context.Context, SessionInfo, downstream.Frame) error {
+			return nil
+		}
+	}
+
+	return &Listener{
+		listener: listener,
+		handler:  handler,
+		hooks:    hooks,
+		options:  options,
+		sessions: make(map[uint64]sessionState),
+	}, nil
+}
+
+func (listener *Listener) Serve(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	stopContextWatcher := make(chan struct{})
+	defer close(stopContextWatcher)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = listener.Close()
+		case <-stopContextWatcher:
+		}
+	}()
+
+	for {
+		connection, err := listener.listener.Accept()
+		if err != nil {
+			if listener.isClosedError(err) || ctx.Err() != nil || listener.isClosed() {
+				return nil
+			}
+
+			listener.recordError(SessionInfo{}, err)
+			continue
+		}
+
+		sessionInfo := listener.registerSession(connection)
+		parser := listener.options.ParserFactory()
+
+		listener.waitGroup.Add(1)
+		go listener.serveSession(ctx, sessionInfo, connection, parser)
+	}
+}
+
+func (listener *Listener) Close() error {
+	var closeErr error
+
+	listener.closeOnce.Do(func() {
+		activeConnections := listener.markClosedAndCollectConnections()
+
+		if err := listener.listener.Close(); err != nil && !listener.isClosedError(err) {
+			closeErr = err
+		}
+
+		for _, connection := range activeConnections {
+			_ = connection.Close()
+		}
+
+		listener.waitGroup.Wait()
+	})
+
+	return closeErr
+}
+
+func (listener *Listener) Sessions() []SessionInfo {
+	listener.mutex.Lock()
+	sessions := make([]SessionInfo, 0, len(listener.sessions))
+	for _, state := range listener.sessions {
+		sessions = append(sessions, state.info)
+	}
+	listener.mutex.Unlock()
+
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].ID < sessions[j].ID
+	})
+
+	return sessions
+}
+
+func (listener *Listener) Metrics() Metrics {
+	listener.mutex.Lock()
+	metrics := listener.metrics
+	listener.mutex.Unlock()
+
+	return metrics
+}
+
+func (listener *Listener) serveSession(
+	ctx context.Context,
+	sessionInfo SessionInfo,
+	connection net.Conn,
+	parser Parser,
+) {
+	defer listener.waitGroup.Done()
+	defer func() {
+		_ = connection.Close()
+	}()
+
+	var disconnectCause error = io.EOF
+	defer func() {
+		listener.unregisterSession(sessionInfo.ID, disconnectCause)
+	}()
+
+	for {
+		if err := setReadDeadline(connection, listener.options.ReadTimeout); err != nil {
+			disconnectCause = err
+			listener.recordError(sessionInfo, err)
+			return
+		}
+
+		frame, err := parser.Parse(connection)
+		if err != nil {
+			switch {
+			case isTimeoutError(err):
+				continue
+			case errors.Is(err, io.EOF) || listener.isClosedError(err):
+				disconnectCause = err
+				return
+			case errors.Is(err, southboundens.ErrMalformedFrame):
+				listener.recordError(sessionInfo, err)
+				continue
+			default:
+				disconnectCause = err
+				listener.recordError(sessionInfo, err)
+				return
+			}
+		}
+
+		listener.recordFrame()
+		if err := listener.handler(ctx, sessionInfo, frame); err != nil {
+			listener.recordError(sessionInfo, err)
+		}
+	}
+}
+
+func (listener *Listener) registerSession(connection net.Conn) SessionInfo {
+	listener.mutex.Lock()
+	listener.nextSessionID++
+	sessionInfo := SessionInfo{
+		ID:          listener.nextSessionID,
+		RemoteAddr:  connection.RemoteAddr().String(),
+		ConnectedAt: time.Now().UTC(),
+	}
+	listener.sessions[sessionInfo.ID] = sessionState{
+		info: sessionInfo,
+		conn: connection,
+	}
+	listener.metrics.ActiveSessions++
+	listener.metrics.TotalConnections++
+	connectHook := listener.hooks.OnConnect
+	listener.mutex.Unlock()
+
+	if connectHook != nil {
+		connectHook(sessionInfo)
+	}
+
+	return sessionInfo
+}
+
+func (listener *Listener) unregisterSession(sessionID uint64, cause error) {
+	listener.mutex.Lock()
+	state, found := listener.sessions[sessionID]
+	if found {
+		delete(listener.sessions, sessionID)
+		if listener.metrics.ActiveSessions > 0 {
+			listener.metrics.ActiveSessions--
+		}
+		listener.metrics.TotalDisconnects++
+	}
+	disconnectHook := listener.hooks.OnDisconnect
+	listener.mutex.Unlock()
+
+	if found && disconnectHook != nil {
+		disconnectHook(state.info, cause)
+	}
+}
+
+func (listener *Listener) recordError(sessionInfo SessionInfo, err error) {
+	listener.mutex.Lock()
+	listener.metrics.TotalErrors++
+	errorHook := listener.hooks.OnError
+	listener.mutex.Unlock()
+
+	if errorHook != nil {
+		errorHook(sessionInfo, err)
+	}
+}
+
+func (listener *Listener) recordFrame() {
+	listener.mutex.Lock()
+	listener.metrics.TotalFrames++
+	listener.mutex.Unlock()
+}
+
+func (listener *Listener) markClosedAndCollectConnections() []net.Conn {
+	listener.mutex.Lock()
+	listener.closed = true
+
+	activeConnections := make([]net.Conn, 0, len(listener.sessions))
+	for _, state := range listener.sessions {
+		activeConnections = append(activeConnections, state.conn)
+	}
+
+	listener.mutex.Unlock()
+	return activeConnections
+}
+
+func (listener *Listener) isClosed() bool {
+	listener.mutex.Lock()
+	closed := listener.closed
+	listener.mutex.Unlock()
+
+	return closed
+}
+
+func (listener *Listener) isClosedError(err error) bool {
+	if errors.Is(err, net.ErrClosed) {
+		return true
+	}
+
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "use of closed network connection")
+}
+
+func setReadDeadline(connection net.Conn, timeout time.Duration) error {
+	if timeout <= 0 {
+		return connection.SetReadDeadline(time.Time{})
+	}
+
+	return connection.SetReadDeadline(time.Now().Add(timeout))
+}
+
+func isTimeoutError(err error) bool {
+	var netError net.Error
+	if errors.As(err, &netError) {
+		return netError.Timeout()
+	}
+
+	return false
+}

--- a/internal/northbound/ens/listener_test.go
+++ b/internal/northbound/ens/listener_test.go
@@ -1,0 +1,366 @@
+package ens
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundens "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/ens"
+)
+
+func TestListenerSupportsConcurrentSessions(t *testing.T) {
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("expected listener setup success, got %v", err)
+	}
+
+	connectEvents := make(chan SessionInfo, 8)
+	disconnectEvents := make(chan SessionInfo, 8)
+	errorEvents := make(chan error, 8)
+	frameEvents := make(chan frameEvent, 8)
+
+	listener, err := NewListener(
+		tcpListener,
+		func(_ context.Context, session SessionInfo, frame downstream.Frame) error {
+			frameEvents <- frameEvent{
+				sessionID: session.ID,
+				frame:     frame,
+			}
+			return nil
+		},
+		Options{
+			ReadTimeout: 200 * time.Millisecond,
+		},
+		Hooks{
+			OnConnect: func(session SessionInfo) {
+				connectEvents <- session
+			},
+			OnDisconnect: func(session SessionInfo, _ error) {
+				disconnectEvents <- session
+			},
+			OnError: func(_ SessionInfo, err error) {
+				errorEvents <- err
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected listener creation success, got %v", err)
+	}
+
+	serveContext, cancelServe := context.WithCancel(context.Background())
+	defer cancelServe()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- listener.Serve(serveContext)
+	}()
+	defer func() {
+		_ = listener.Close()
+		<-serveErr
+	}()
+
+	client1 := mustDialTCP(t, tcpListener.Addr().String())
+	client2 := mustDialTCP(t, tcpListener.Addr().String())
+	defer client1.Close()
+	defer client2.Close()
+
+	waitForEventCount(t, connectEvents, 2)
+
+	writeENSByte(t, client1, 0x31)
+	writeENSByte(t, client2, southboundens.ENSByteSync)
+
+	receivedFrames := waitForFrameEvents(t, frameEvents, 2)
+	receivedPayloads := make([]byte, 0, len(receivedFrames))
+	for _, event := range receivedFrames {
+		if event.frame.Command != byte(southboundens.ENSCommandData) {
+			t.Fatalf("expected command 0x%02X, got 0x%02X", byte(southboundens.ENSCommandData), event.frame.Command)
+		}
+		receivedPayloads = append(receivedPayloads, event.frame.Payload[0])
+	}
+	sort.Slice(receivedPayloads, func(i, j int) bool {
+		return receivedPayloads[i] < receivedPayloads[j]
+	})
+	if !reflect.DeepEqual(receivedPayloads, []byte{0x31, southboundens.ENSByteSync}) {
+		t.Fatalf("expected payloads [0x31 0xAA], got %#v", receivedPayloads)
+	}
+
+	if err := client1.Close(); err != nil {
+		t.Fatalf("expected client1 close success, got %v", err)
+	}
+	if err := client2.Close(); err != nil {
+		t.Fatalf("expected client2 close success, got %v", err)
+	}
+
+	waitForEventCount(t, disconnectEvents, 2)
+
+	metrics := listener.Metrics()
+	if metrics.ActiveSessions != 0 {
+		t.Fatalf("expected active sessions 0, got %d", metrics.ActiveSessions)
+	}
+	if metrics.TotalConnections != 2 {
+		t.Fatalf("expected total connections 2, got %d", metrics.TotalConnections)
+	}
+	if metrics.TotalDisconnects != 2 {
+		t.Fatalf("expected total disconnects 2, got %d", metrics.TotalDisconnects)
+	}
+	if metrics.TotalFrames != 2 {
+		t.Fatalf("expected total frames 2, got %d", metrics.TotalFrames)
+	}
+	if metrics.TotalErrors != 0 {
+		t.Fatalf("expected total errors 0, got %d", metrics.TotalErrors)
+	}
+
+	activeSessions := listener.Sessions()
+	if len(activeSessions) != 0 {
+		t.Fatalf("expected zero active sessions, got %d", len(activeSessions))
+	}
+
+	select {
+	case err := <-errorEvents:
+		t.Fatalf("expected no error hook events, got %v", err)
+	default:
+	}
+}
+
+func TestListenerMalformedFrameErrorAndRecovery(t *testing.T) {
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("expected listener setup success, got %v", err)
+	}
+
+	connectEvents := make(chan SessionInfo, 4)
+	disconnectEvents := make(chan SessionInfo, 4)
+	errorEvents := make(chan error, 4)
+	frameEvents := make(chan downstream.Frame, 4)
+
+	listener, err := NewListener(
+		tcpListener,
+		func(_ context.Context, _ SessionInfo, frame downstream.Frame) error {
+			frameEvents <- frame
+			return nil
+		},
+		Options{
+			ReadTimeout: 200 * time.Millisecond,
+		},
+		Hooks{
+			OnConnect: func(session SessionInfo) {
+				connectEvents <- session
+			},
+			OnDisconnect: func(session SessionInfo, _ error) {
+				disconnectEvents <- session
+			},
+			OnError: func(_ SessionInfo, err error) {
+				errorEvents <- err
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected listener creation success, got %v", err)
+	}
+
+	serveContext, cancelServe := context.WithCancel(context.Background())
+	defer cancelServe()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- listener.Serve(serveContext)
+	}()
+	defer func() {
+		_ = listener.Close()
+		<-serveErr
+	}()
+
+	client := mustDialTCP(t, tcpListener.Addr().String())
+	defer client.Close()
+
+	waitForEventCount(t, connectEvents, 1)
+
+	_, err = client.Write([]byte{southboundens.ENSByteEscape, 0x02})
+	if err != nil {
+		t.Fatalf("expected malformed write success, got %v", err)
+	}
+
+	writeENSByte(t, client, 0x44)
+
+	waitForErrorCount(t, errorEvents, 1)
+
+	frame := waitForFrameEvent(t, frameEvents)
+	expectedFrame := downstream.Frame{
+		Command: byte(southboundens.ENSCommandData),
+		Payload: []byte{0x44},
+	}
+	if !reflect.DeepEqual(frame, expectedFrame) {
+		t.Fatalf("expected recovered frame %#v, got %#v", expectedFrame, frame)
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("expected client close success, got %v", err)
+	}
+
+	waitForEventCount(t, disconnectEvents, 1)
+
+	metrics := listener.Metrics()
+	if metrics.TotalErrors != 1 {
+		t.Fatalf("expected total errors 1, got %d", metrics.TotalErrors)
+	}
+	if metrics.TotalFrames != 1 {
+		t.Fatalf("expected total frames 1, got %d", metrics.TotalFrames)
+	}
+}
+
+func TestListenerReadTimeoutKeepsSessionAlive(t *testing.T) {
+	tcpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("expected listener setup success, got %v", err)
+	}
+
+	connectEvents := make(chan SessionInfo, 2)
+	frameEvents := make(chan downstream.Frame, 2)
+
+	listener, err := NewListener(
+		tcpListener,
+		func(_ context.Context, _ SessionInfo, frame downstream.Frame) error {
+			frameEvents <- frame
+			return nil
+		},
+		Options{
+			ReadTimeout: 50 * time.Millisecond,
+		},
+		Hooks{
+			OnConnect: func(session SessionInfo) {
+				connectEvents <- session
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected listener creation success, got %v", err)
+	}
+
+	serveContext, cancelServe := context.WithCancel(context.Background())
+	defer cancelServe()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- listener.Serve(serveContext)
+	}()
+	defer func() {
+		_ = listener.Close()
+		<-serveErr
+	}()
+
+	client := mustDialTCP(t, tcpListener.Addr().String())
+	defer client.Close()
+
+	waitForEventCount(t, connectEvents, 1)
+
+	time.Sleep(150 * time.Millisecond)
+
+	writeENSByte(t, client, 0x51)
+
+	frame := waitForFrameEvent(t, frameEvents)
+	expectedFrame := downstream.Frame{
+		Command: byte(southboundens.ENSCommandData),
+		Payload: []byte{0x51},
+	}
+	if !reflect.DeepEqual(frame, expectedFrame) {
+		t.Fatalf("expected frame %#v, got %#v", expectedFrame, frame)
+	}
+
+	metrics := listener.Metrics()
+	if metrics.TotalErrors != 0 {
+		t.Fatalf("expected total errors 0 after timeout handling, got %d", metrics.TotalErrors)
+	}
+}
+
+func mustDialTCP(t *testing.T, address string) net.Conn {
+	t.Helper()
+
+	client, err := net.Dial("tcp", address)
+	if err != nil {
+		t.Fatalf("expected dial success, got %v", err)
+	}
+
+	return client
+}
+
+func writeENSByte(t *testing.T, client net.Conn, payload byte) {
+	t.Helper()
+
+	encoded := southboundens.EncodeENS([]byte{payload})
+	_, err := client.Write(encoded)
+	if err != nil {
+		t.Fatalf("expected frame write success, got %v", err)
+	}
+}
+
+func waitForEventCount(t *testing.T, events <-chan SessionInfo, expectedCount int) []SessionInfo {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	out := make([]SessionInfo, 0, expectedCount)
+	for len(out) < expectedCount {
+		select {
+		case event := <-events:
+			out = append(out, event)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d session events, got %d", expectedCount, len(out))
+		}
+	}
+
+	return out
+}
+
+func waitForFrameEvents(t *testing.T, events <-chan frameEvent, expectedCount int) []frameEvent {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	out := make([]frameEvent, 0, expectedCount)
+	for len(out) < expectedCount {
+		select {
+		case event := <-events:
+			out = append(out, event)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d frame events, got %d", expectedCount, len(out))
+		}
+	}
+
+	return out
+}
+
+func waitForFrameEvent(t *testing.T, events <-chan downstream.Frame) downstream.Frame {
+	t.Helper()
+
+	select {
+	case frame := <-events:
+		return frame
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for frame event")
+		return downstream.Frame{}
+	}
+}
+
+func waitForErrorCount(t *testing.T, events <-chan error, expectedCount int) []error {
+	t.Helper()
+
+	deadline := time.After(2 * time.Second)
+	out := make([]error, 0, expectedCount)
+	for len(out) < expectedCount {
+		select {
+		case event := <-events:
+			out = append(out, event)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d error events, got %d", expectedCount, len(out))
+		}
+	}
+
+	return out
+}
+
+type frameEvent struct {
+	sessionID uint64
+	frame     downstream.Frame
+}


### PR DESCRIPTION
Fixes #7

## Summary
- add a focused northbound ENS listener with accept loop and per-session connection handling
- support concurrent sessions with deterministic session IDs and per-session ENS decoding
- expose lifecycle hooks (`on connect`, `on disconnect`, `on error`) plus metrics/session snapshot APIs
- keep API and behavior aligned with the ENH listener for future shared session management work
- add integration tests for 2 concurrent clients, malformed frame recovery, and read-timeout handling

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/terminology-gate.sh`