### PR TITLE
M1: Docs gate sync for transport + listeners

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,20 +2,34 @@
 
 ## Goal
 
-`helianthus-ebus-adapter-proxy` bridges downstream eBUS frames to an upstream adapter stream.
+`helianthus-ebus-adapter-proxy` owns one southbound adapter connection and exposes concurrent northbound listener sessions.
 
 ## Current package layout
 
 - `cmd/helianthus-ebus-adapter-proxy`: executable entry point.
+- `internal/southbound/enh`: ENH southbound transport codec and driver.
+- `internal/southbound/ens`: ENS southbound transport codec and driver.
+- `internal/northbound/enh`: ENH northbound multi-session listener.
+- `internal/northbound/ens`: ENS northbound multi-session listener.
 - `internal/domain/downstream`: downstream frame contracts and client interface.
 - `internal/domain/upstream`: upstream message contracts and client interface.
 - `internal/domain/routing`: routing contract between downstream and upstream domains.
 - `internal/proxy`: service orchestration for routing and publication.
 
-## Runtime flow
+## Runtime path (M1)
 
-1. Receive a downstream frame.
-2. Route the frame into an upstream message.
-3. Publish the message using the upstream client.
+1. Initialize one southbound owner connection (ENH or ENS) to the adapter.
+2. Start northbound listeners (ENH and/or ENS) that accept concurrent client sessions.
+3. Decode per-session transport frames and convert them into `downstream.Frame` values.
+4. Route frames through domain/proxy orchestration toward upstream publication.
 
-This bootstrap keeps implementations minimal while establishing stable domain boundaries.
+## Session behavior
+
+- Northbound listeners expose deterministic lifecycle hooks: connect, disconnect, error.
+- Metrics snapshots include active sessions plus total connection/disconnect/error/frame counters.
+- Malformed transport data is reported and parsing continues when recovery is possible.
+
+## Terminology policy
+
+- Runtime and protocol roles are documented as `initiator` and `target`.
+- Legacy wording may appear only when mirroring external protocol definitions, with local clarification.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -6,17 +6,33 @@
 - Keep domain contracts in `internal/domain/*`.
 - Keep orchestration in `internal/proxy`.
 - Keep executable wiring in `cmd/*`.
+- Keep transport drivers in `internal/southbound/*`.
+- Keep northbound listeners in `internal/northbound/*`.
 
 ## Code quality
 
 - Format with `gofmt`.
 - Keep interfaces small and domain-focused.
 - Avoid introducing dependencies without clear need.
+- Keep transport/listener APIs coherent across ENH and ENS packages.
+
+## Testing expectations
+
+- Transport codec tests must cover framing behavior, malformed input behavior, and recovery paths.
+- Transport driver tests must cover lifecycle behavior, timeout mapping, reconnect behavior, and error propagation.
+- Listener tests must cover concurrent sessions (2+ clients), lifecycle hooks/metrics, malformed-frame recovery, and timeout handling.
+- Prefer deterministic assertions (stable counters/order) over timing-sensitive assertions.
+
+## Terminology
+
+- Preferred terms: `initiator`, `target`, `allow`, `block`.
+- If legacy external wording must be referenced for compatibility, scope it to the external context and clarify preferred repository terms nearby.
+- Terminology policy is enforced by `./scripts/terminology-gate.sh`.
 
 ## Validation
 
 Before pushing changes, run:
 
-1. `go test ./...`
-2. `go vet ./...`
+1. `GOWORK=off go test ./...`
+2. `GOWORK=off go vet ./...`
 3. `./scripts/terminology-gate.sh`

--- a/README.md
+++ b/README.md
@@ -1,20 +1,36 @@
 # helianthus-ebus-adapter-proxy
 
-Bootstrap repository for an eBUS adapter proxy service.
+eBUS adapter proxy service with southbound transport drivers and northbound multi-session listeners.
 
 ## What is included
 
-- Go module initialization.
-- Domain package skeletons for downstream, upstream, and routing concerns.
-- Proxy service skeleton with unit tests.
+- Southbound drivers:
+  - `internal/southbound/enh`: ENH dial/read/write lifecycle with reconnect hooks and timeout handling.
+  - `internal/southbound/ens`: ENS dial/read/write lifecycle with reconnect hooks and timeout handling.
+- Northbound listeners:
+  - `internal/northbound/enh`: concurrent ENH listener sessions with metrics and lifecycle hooks.
+  - `internal/northbound/ens`: concurrent ENS listener sessions with metrics and lifecycle hooks.
+- Domain contracts and proxy orchestration in `internal/domain/*` and `internal/proxy`.
 - CI workflow that runs tests, vet, and terminology checks.
-- Repository guardrail documents.
+- Repository guardrail and architecture documents.
+
+## Runtime shape (M1)
+
+- One southbound owner connection to the physical adapter (ENH or ENS).
+- Multiple concurrent northbound client sessions (ENH and ENS listeners).
+- Listener sessions decode transport frames and pass them to proxy domain handling.
+
+## Terminology policy
+
+- Use `initiator` and `target` across code and docs.
+- If integration with an external protocol/source requires legacy wording, keep it scoped to that source and add a short clarification in the same context.
+- Keep repository terminology gate-compliant (`./scripts/terminology-gate.sh`).
 
 ## Quick start
 
 ```bash
-go test ./...
-go vet ./...
+GOWORK=off go test ./...
+GOWORK=off go vet ./...
 ./scripts/terminology-gate.sh
 ```
 


### PR DESCRIPTION
Fixes #29

## Summary
- update README to reflect M1 southbound ENH/ENS drivers and northbound ENH/ENS listeners
- update architecture docs to describe runtime path: single southbound owner + northbound multi-session listeners
- update conventions with transport/listener test expectations and terminology policy guidance
- clarify terminology policy around preferred `initiator`/`target` wording and scoped legacy exceptions

## Validation
- `./scripts/terminology-gate.sh`
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`