### PR TITLE
M2: Backpressure + bounded queues

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -21,6 +21,7 @@
 - Transport codec tests must cover framing behavior, malformed input behavior, and recovery paths.
 - Transport driver tests must cover lifecycle behavior, timeout mapping, reconnect behavior, and error propagation.
 - Listener tests must cover concurrent sessions (2+ clients), lifecycle hooks/metrics, malformed-frame recovery, and timeout handling.
+- Session manager tests must cover bounded queue backpressure behavior, overflow error taxonomy, and rejected/dropped metric counters.
 - Prefer deterministic assertions (stable counters/order) over timing-sensitive assertions.
 
 ## Terminology

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ eBUS adapter proxy service with southbound transport drivers and northbound mult
 - Multiple concurrent northbound client sessions (ENH and ENS listeners).
 - Listener sessions decode transport frames and pass them to proxy domain handling.
 
+## Queue backpressure semantics (M2)
+
+- Session queues are bounded via `internal/session.Options{InboundCapacity, OutboundCapacity}`.
+- `EnqueueInbound` and `EnqueueOutbound` reject when a queue is full and return typed `BackpressureError` values.
+- Rejections classify as `ErrInboundBackpressure` or `ErrOutboundBackpressure`, and still satisfy `errors.Is(err, ErrQueueFull)`.
+- Disconnect (`Unregister`) clears queued frames for that session and counts them as dropped.
+- `internal/session.Manager.Metrics()` and per-session snapshots expose deterministic `rejected_*` and `dropped_*` counters.
+
 ## Terminology policy
 
 - Use `initiator` and `target` across code and docs.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -14,6 +14,8 @@ var (
 	ErrSessionNotFound         = errors.New("session not found")
 	ErrSessionAlreadyConnected = errors.New("session already connected")
 	ErrSessionNotConnected     = errors.New("session not connected")
+	ErrInboundBackpressure     = errors.New("inbound queue backpressure")
+	ErrOutboundBackpressure    = errors.New("outbound queue backpressure")
 	ErrQueueFull               = errors.New("session queue is full")
 )
 
@@ -23,6 +25,13 @@ const (
 	EventTypeConnected    EventType = "connected"
 	EventTypeDisconnected EventType = "disconnected"
 	EventTypeReconnected  EventType = "reconnected"
+)
+
+type QueueDirection string
+
+const (
+	QueueDirectionInbound  QueueDirection = "inbound"
+	QueueDirectionOutbound QueueDirection = "outbound"
 )
 
 type Identity struct {
@@ -40,6 +49,43 @@ type Session struct {
 	ReconnectCount uint64
 	InboundDepth   int
 	OutboundDepth  int
+	QueueMetrics   QueueMetrics
+}
+
+type QueueMetrics struct {
+	RejectedInbound  uint64
+	RejectedOutbound uint64
+	DroppedInbound   uint64
+	DroppedOutbound  uint64
+}
+
+// BackpressureError reports enqueue rejection caused by bounded queue capacity.
+type BackpressureError struct {
+	SessionID uint64
+	Direction QueueDirection
+	Capacity  int
+}
+
+func (errorValue BackpressureError) Error() string {
+	return fmt.Sprintf(
+		"%s frame rejected due to queue backpressure (session=%d capacity=%d)",
+		errorValue.Direction,
+		errorValue.SessionID,
+		errorValue.Capacity,
+	)
+}
+
+func (errorValue BackpressureError) Is(target error) bool {
+	switch target {
+	case ErrQueueFull:
+		return true
+	case ErrInboundBackpressure:
+		return errorValue.Direction == QueueDirectionInbound
+	case ErrOutboundBackpressure:
+		return errorValue.Direction == QueueDirectionOutbound
+	default:
+		return false
+	}
 }
 
 type Event struct {
@@ -65,6 +111,7 @@ type Manager struct {
 	hooks        Hooks
 	identityToID map[string]uint64
 	sessions     map[uint64]*sessionState
+	queueMetrics QueueMetrics
 	nextID       uint64
 }
 
@@ -77,6 +124,7 @@ type sessionState struct {
 	reconnectCount uint64
 	inboundQueue   *frameQueue
 	outboundQueue  *frameQueue
+	queueMetrics   QueueMetrics
 }
 
 type frameQueue struct {
@@ -163,8 +211,12 @@ func (manager *Manager) Unregister(sessionID uint64, cause error) (Session, erro
 
 	state.connected = false
 	state.disconnectedAt = time.Now().UTC()
-	state.inboundQueue.clear()
-	state.outboundQueue.clear()
+	droppedInbound := state.inboundQueue.clear()
+	droppedOutbound := state.outboundQueue.clear()
+	state.queueMetrics.DroppedInbound += uint64(droppedInbound)
+	state.queueMetrics.DroppedOutbound += uint64(droppedOutbound)
+	manager.queueMetrics.DroppedInbound += uint64(droppedInbound)
+	manager.queueMetrics.DroppedOutbound += uint64(droppedOutbound)
 
 	event := Event{
 		Type:    EventTypeDisconnected,
@@ -258,40 +310,67 @@ func (manager *Manager) ActiveSessions() []Session {
 	return sessions
 }
 
-func (manager *Manager) EnqueueInbound(sessionID uint64, frame downstream.Frame) error {
+// Metrics returns deterministic aggregate queue backpressure counters.
+func (manager *Manager) Metrics() QueueMetrics {
 	manager.mutex.RLock()
+	metrics := manager.queueMetrics
+	manager.mutex.RUnlock()
+
+	return metrics
+}
+
+func (manager *Manager) EnqueueInbound(sessionID uint64, frame downstream.Frame) error {
+	manager.mutex.Lock()
 	state, found := manager.sessions[sessionID]
 	if !found {
-		manager.mutex.RUnlock()
+		manager.mutex.Unlock()
 		return ErrSessionNotFound
 	}
 
 	if !state.connected {
-		manager.mutex.RUnlock()
+		manager.mutex.Unlock()
 		return ErrSessionNotConnected
 	}
 
 	err := state.inboundQueue.enqueue(frame)
-	manager.mutex.RUnlock()
+	if errors.Is(err, ErrQueueFull) {
+		state.queueMetrics.RejectedInbound++
+		manager.queueMetrics.RejectedInbound++
+		err = BackpressureError{
+			SessionID: sessionID,
+			Direction: QueueDirectionInbound,
+			Capacity:  state.inboundQueue.capacity,
+		}
+	}
+	manager.mutex.Unlock()
 
 	return err
 }
 
 func (manager *Manager) EnqueueOutbound(sessionID uint64, frame downstream.Frame) error {
-	manager.mutex.RLock()
+	manager.mutex.Lock()
 	state, found := manager.sessions[sessionID]
 	if !found {
-		manager.mutex.RUnlock()
+		manager.mutex.Unlock()
 		return ErrSessionNotFound
 	}
 
 	if !state.connected {
-		manager.mutex.RUnlock()
+		manager.mutex.Unlock()
 		return ErrSessionNotConnected
 	}
 
 	err := state.outboundQueue.enqueue(frame)
-	manager.mutex.RUnlock()
+	if errors.Is(err, ErrQueueFull) {
+		state.queueMetrics.RejectedOutbound++
+		manager.queueMetrics.RejectedOutbound++
+		err = BackpressureError{
+			SessionID: sessionID,
+			Direction: QueueDirectionOutbound,
+			Capacity:  state.outboundQueue.capacity,
+		}
+	}
+	manager.mutex.Unlock()
 
 	return err
 }
@@ -344,6 +423,7 @@ func (state *sessionState) snapshot() Session {
 		ReconnectCount: state.reconnectCount,
 		InboundDepth:   state.inboundQueue.depth(),
 		OutboundDepth:  state.outboundQueue.depth(),
+		QueueMetrics:   state.queueMetrics,
 	}
 }
 
@@ -387,10 +467,13 @@ func (queue *frameQueue) depth() int {
 	return depth
 }
 
-func (queue *frameQueue) clear() {
+func (queue *frameQueue) clear() int {
 	queue.mutex.Lock()
+	dropped := len(queue.items)
 	queue.items = queue.items[:0]
 	queue.mutex.Unlock()
+
+	return dropped
 }
 
 func cloneFrame(frame downstream.Frame) downstream.Frame {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -305,6 +305,136 @@ func TestManagerBoundedQueuesAndReconnectReset(t *testing.T) {
 	}
 }
 
+func TestManagerBackpressureErrorTaxonomyAndMetrics(t *testing.T) {
+	manager := NewManager(
+		Options{
+			InboundCapacity:  1,
+			OutboundCapacity: 1,
+		},
+		Hooks{},
+	)
+
+	identity := Identity{
+		ClientID:   "client-backpressure",
+		Protocol:   "ens",
+		RemoteAddr: "127.0.0.1:32001",
+	}
+
+	session, err := manager.Register(identity)
+	if err != nil {
+		t.Fatalf("expected register success, got %v", err)
+	}
+
+	if err := manager.EnqueueInbound(session.ID, downstream.Frame{Payload: []byte{0x01}}); err != nil {
+		t.Fatalf("expected enqueue inbound success, got %v", err)
+	}
+	if err := manager.EnqueueOutbound(session.ID, downstream.Frame{Payload: []byte{0x02}}); err != nil {
+		t.Fatalf("expected enqueue outbound success, got %v", err)
+	}
+
+	inboundErr := manager.EnqueueInbound(session.ID, downstream.Frame{Payload: []byte{0x03}})
+	if !errors.Is(inboundErr, ErrQueueFull) {
+		t.Fatalf("expected queue full error, got %v", inboundErr)
+	}
+	if !errors.Is(inboundErr, ErrInboundBackpressure) {
+		t.Fatalf("expected inbound backpressure error, got %v", inboundErr)
+	}
+	if errors.Is(inboundErr, ErrOutboundBackpressure) {
+		t.Fatalf("did not expect outbound backpressure classification for inbound enqueue")
+	}
+
+	var inboundBackpressureError BackpressureError
+	if !errors.As(inboundErr, &inboundBackpressureError) {
+		t.Fatalf("expected typed backpressure error, got %T", inboundErr)
+	}
+	if inboundBackpressureError.SessionID != session.ID {
+		t.Fatalf("expected inbound backpressure session %d, got %d", session.ID, inboundBackpressureError.SessionID)
+	}
+	if inboundBackpressureError.Direction != QueueDirectionInbound {
+		t.Fatalf("expected inbound direction, got %s", inboundBackpressureError.Direction)
+	}
+	if inboundBackpressureError.Capacity != 1 {
+		t.Fatalf("expected inbound backpressure capacity 1, got %d", inboundBackpressureError.Capacity)
+	}
+
+	outboundErr := manager.EnqueueOutbound(session.ID, downstream.Frame{Payload: []byte{0x04}})
+	if !errors.Is(outboundErr, ErrQueueFull) {
+		t.Fatalf("expected queue full error, got %v", outboundErr)
+	}
+	if !errors.Is(outboundErr, ErrOutboundBackpressure) {
+		t.Fatalf("expected outbound backpressure error, got %v", outboundErr)
+	}
+	if errors.Is(outboundErr, ErrInboundBackpressure) {
+		t.Fatalf("did not expect inbound backpressure classification for outbound enqueue")
+	}
+
+	var outboundBackpressureError BackpressureError
+	if !errors.As(outboundErr, &outboundBackpressureError) {
+		t.Fatalf("expected typed backpressure error, got %T", outboundErr)
+	}
+	if outboundBackpressureError.SessionID != session.ID {
+		t.Fatalf("expected outbound backpressure session %d, got %d", session.ID, outboundBackpressureError.SessionID)
+	}
+	if outboundBackpressureError.Direction != QueueDirectionOutbound {
+		t.Fatalf("expected outbound direction, got %s", outboundBackpressureError.Direction)
+	}
+	if outboundBackpressureError.Capacity != 1 {
+		t.Fatalf("expected outbound backpressure capacity 1, got %d", outboundBackpressureError.Capacity)
+	}
+
+	snapshotBeforeDisconnect, err := manager.Snapshot(session.ID)
+	if err != nil {
+		t.Fatalf("expected snapshot success, got %v", err)
+	}
+
+	expectedBeforeDisconnect := QueueMetrics{
+		RejectedInbound:  1,
+		RejectedOutbound: 1,
+	}
+	if !reflect.DeepEqual(snapshotBeforeDisconnect.QueueMetrics, expectedBeforeDisconnect) {
+		t.Fatalf(
+			"expected session queue metrics %#v before disconnect, got %#v",
+			expectedBeforeDisconnect,
+			snapshotBeforeDisconnect.QueueMetrics,
+		)
+	}
+
+	aggregateMetrics := manager.Metrics()
+	if !reflect.DeepEqual(aggregateMetrics, expectedBeforeDisconnect) {
+		t.Fatalf("expected aggregate metrics %#v before disconnect, got %#v", expectedBeforeDisconnect, aggregateMetrics)
+	}
+
+	disconnectedSession, err := manager.Unregister(session.ID, nil)
+	if err != nil {
+		t.Fatalf("expected unregister success, got %v", err)
+	}
+
+	expectedAfterDisconnect := QueueMetrics{
+		RejectedInbound:  1,
+		RejectedOutbound: 1,
+		DroppedInbound:   1,
+		DroppedOutbound:  1,
+	}
+
+	if !reflect.DeepEqual(disconnectedSession.QueueMetrics, expectedAfterDisconnect) {
+		t.Fatalf("expected disconnected queue metrics %#v, got %#v", expectedAfterDisconnect, disconnectedSession.QueueMetrics)
+	}
+
+	aggregateMetrics = manager.Metrics()
+	if !reflect.DeepEqual(aggregateMetrics, expectedAfterDisconnect) {
+		t.Fatalf("expected aggregate metrics %#v after disconnect, got %#v", expectedAfterDisconnect, aggregateMetrics)
+	}
+
+	reconnectedSession, err := manager.Reconnect(identity)
+	if err != nil {
+		t.Fatalf("expected reconnect success, got %v", err)
+	}
+
+	if !reflect.DeepEqual(reconnectedSession.QueueMetrics, expectedAfterDisconnect) {
+		t.Fatalf("expected reconnect to preserve queue metrics %#v, got %#v", expectedAfterDisconnect, reconnectedSession.QueueMetrics)
+	}
+}
+
 func TestManagerConcurrentQueueOpsRespectConnectedStateBarriers(t *testing.T) {
 	manager := NewManager(
 		Options{


### PR DESCRIPTION
## Summary
- extend session manager enqueue paths with explicit backpressure error taxonomy for inbound/outbound queues
- add deterministic rejected/dropped queue metrics on session snapshots and aggregate manager metrics
- document queue overflow semantics and add focused deterministic tests for limits, overflow behavior, and metrics counters

Fixes #10