### PR TITLE
M2: Docs gate sync for session/scheduler/backpressure

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,23 +11,41 @@
 - `internal/southbound/ens`: ENS southbound transport codec and driver.
 - `internal/northbound/enh`: ENH northbound multi-session listener.
 - `internal/northbound/ens`: ENS northbound multi-session listener.
+- `internal/session`: session registry, lifecycle hooks, and bounded per-session queues.
+- `internal/scheduler/write`: adaptive write scheduler with starvation guard.
 - `internal/domain/downstream`: downstream frame contracts and client interface.
 - `internal/domain/upstream`: upstream message contracts and client interface.
 - `internal/domain/routing`: routing contract between downstream and upstream domains.
 - `internal/proxy`: service orchestration for routing and publication.
 
-## Runtime path (M1)
+## Runtime path (M2)
 
 1. Initialize one southbound owner connection (ENH or ENS) to the adapter.
 2. Start northbound listeners (ENH and/or ENS) that accept concurrent client sessions.
-3. Decode per-session transport frames and convert them into `downstream.Frame` values.
-4. Route frames through domain/proxy orchestration toward upstream publication.
+3. Register client sessions in `internal/session.Manager` with stable IDs and bounded inbound/outbound queues.
+4. Decode per-session transport frames and enqueue/dequeue `downstream.Frame` values per session.
+5. Build scheduler candidates from per-session queue depth and choose next writer via `AdaptiveScheduler`.
+6. Route selected frames through domain/proxy orchestration toward upstream publication.
 
 ## Session behavior
 
 - Northbound listeners expose deterministic lifecycle hooks: connect, disconnect, error.
 - Metrics snapshots include active sessions plus total connection/disconnect/error/frame counters.
 - Malformed transport data is reported and parsing continues when recovery is possible.
+
+## Backpressure and overflow behavior
+
+- Queue limits are configured through `session.Options{InboundCapacity, OutboundCapacity}`.
+- Full-queue enqueue operations reject with `BackpressureError` and stable sentinel matching:
+  `ErrInboundBackpressure` or `ErrOutboundBackpressure`, and `ErrQueueFull`.
+- `Unregister` clears per-session queue contents; cleared entries are counted as dropped frames.
+- Stable queue metric counters are exposed both per session (`Session.QueueMetrics`) and aggregated (`Manager.Metrics()`):
+  `RejectedInbound`, `RejectedOutbound`, `DroppedInbound`, `DroppedOutbound`.
+
+## Scheduler behavior
+
+- `AdaptiveScheduler` prioritizes queue pressure (`QueueDepth`) and uses deterministic tie-breaking.
+- Starvation guard (`Options.StarvationAfter`) forces service for stale sessions under sustained skewed load.
 
 ## Terminology policy
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -21,7 +21,9 @@
 - Transport codec tests must cover framing behavior, malformed input behavior, and recovery paths.
 - Transport driver tests must cover lifecycle behavior, timeout mapping, reconnect behavior, and error propagation.
 - Listener tests must cover concurrent sessions (2+ clients), lifecycle hooks/metrics, malformed-frame recovery, and timeout handling.
-- Session manager tests must cover bounded queue backpressure behavior, overflow error taxonomy, and rejected/dropped metric counters.
+- Session manager tests must cover bounded queue backpressure behavior, overflow error taxonomy (`ErrInboundBackpressure`, `ErrOutboundBackpressure`, `ErrQueueFull`), and deterministic rejected/dropped metric counters.
+- Scheduler tests must cover deterministic selection behavior, fairness under balanced load, and starvation-guard behavior under skewed sustained load.
+- Scheduler concurrency tests must remain race-safe and verify valid session selection under concurrent `Select` calls.
 - Prefer deterministic assertions (stable counters/order) over timing-sensitive assertions.
 
 ## Terminology

--- a/README.md
+++ b/README.md
@@ -14,19 +14,23 @@ eBUS adapter proxy service with southbound transport drivers and northbound mult
 - CI workflow that runs tests, vet, and terminology checks.
 - Repository guardrail and architecture documents.
 
-## Runtime shape (M1)
+## Runtime shape (M2)
 
 - One southbound owner connection to the physical adapter (ENH or ENS).
 - Multiple concurrent northbound client sessions (ENH and ENS listeners).
 - Listener sessions decode transport frames and pass them to proxy domain handling.
+- `internal/session.Manager` tracks session lifecycle, stable session identity, and bounded per-session queues.
+- `internal/scheduler/write.AdaptiveScheduler` selects the next writer from queue-pressure candidates and applies starvation protection.
 
 ## Queue backpressure semantics (M2)
 
 - Session queues are bounded via `internal/session.Options{InboundCapacity, OutboundCapacity}`.
 - `EnqueueInbound` and `EnqueueOutbound` reject when a queue is full and return typed `BackpressureError` values.
 - Rejections classify as `ErrInboundBackpressure` or `ErrOutboundBackpressure`, and still satisfy `errors.Is(err, ErrQueueFull)`.
+- Backpressure outcomes are stable for callers: `errors.Is(err, ErrInboundBackpressure|ErrOutboundBackpressure|ErrQueueFull)`.
 - Disconnect (`Unregister`) clears queued frames for that session and counts them as dropped.
-- `internal/session.Manager.Metrics()` and per-session snapshots expose deterministic `rejected_*` and `dropped_*` counters.
+- `internal/session.Session.QueueMetrics` and `internal/session.Manager.Metrics()` expose deterministic counters:
+  `RejectedInbound`, `RejectedOutbound`, `DroppedInbound`, `DroppedOutbound`.
 
 ## Terminology policy
 


### PR DESCRIPTION
## Summary
- update README with explicit M2 session manager, adaptive scheduler, and stable backpressure references
- update ARCHITECTURE with per-session queues, adaptive scheduling flow, and overflow/backpressure outcomes
- update CONVENTIONS test expectations for fairness/starvation and backpressure metrics/error taxonomy

Fixes #34