### PR TITLE
M3: Source address policy + soft reserve 0x31

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,15 +5,19 @@ import "time"
 const (
 	SouthboundTransportSerial = "serial"
 	SouthboundTransportTCP    = "tcp"
+
+	SourceAddressReservationModeSoft     = "soft"
+	SourceAddressReservationModeDisabled = "disabled"
 )
 
 type Config struct {
-	Southbound   SouthboundConfig
-	Northbound   NorthboundConfig
-	Clients      ClientsConfig
-	Scheduler    SchedulerConfig
-	AddressGuard AddressGuardConfig
-	Emulation    EmulationConfig
+	Southbound          SouthboundConfig
+	Northbound          NorthboundConfig
+	Clients             ClientsConfig
+	Scheduler           SchedulerConfig
+	AddressGuard        AddressGuardConfig
+	Emulation           EmulationConfig
+	SourceAddressPolicy SourceAddressPolicyConfig
 }
 
 type SouthboundConfig struct {
@@ -55,4 +59,11 @@ type AddressGuardConfig struct {
 type EmulationConfig struct {
 	Enabled                bool
 	VirtualSourceAddresses []uint8
+}
+
+type SourceAddressPolicyConfig struct {
+	AllowedAddresses      []uint8
+	BlockedAddresses      []uint8
+	SoftReservedAddresses []uint8
+	ReservationMode       string
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -64,6 +64,10 @@ func (configuration Config) Validate() error {
 	)
 	validationErrors = append(
 		validationErrors,
+		validateSourceAddressPolicy(configuration.SourceAddressPolicy)...,
+	)
+	validationErrors = append(
+		validationErrors,
 		validateEmulationAddressGuardCompatibility(
 			configuration.Emulation,
 			configuration.AddressGuard,
@@ -296,6 +300,69 @@ func validateEmulation(configuration EmulationConfig) ValidationErrors {
 		validationErrors,
 		validateAddressList("emulation.virtual_source_addresses", configuration.VirtualSourceAddresses)...,
 	)
+
+	return validationErrors
+}
+
+func validateSourceAddressPolicy(configuration SourceAddressPolicyConfig) ValidationErrors {
+	validationErrors := make(ValidationErrors, 0)
+
+	reservationMode := strings.TrimSpace(configuration.ReservationMode)
+	if reservationMode == "" {
+		reservationMode = SourceAddressReservationModeSoft
+	}
+
+	switch reservationMode {
+	case SourceAddressReservationModeSoft, SourceAddressReservationModeDisabled:
+	default:
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "source_address_policy.reservation_mode.invalid",
+			Field:   "source_address_policy.reservation_mode",
+			Message: "reservation mode must be either soft or disabled",
+		})
+	}
+
+	validationErrors = append(
+		validationErrors,
+		validateAddressList(
+			"source_address_policy.allowed_addresses",
+			configuration.AllowedAddresses,
+		)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateAddressList(
+			"source_address_policy.blocked_addresses",
+			configuration.BlockedAddresses,
+		)...,
+	)
+	validationErrors = append(
+		validationErrors,
+		validateAddressList(
+			"source_address_policy.soft_reserved_addresses",
+			configuration.SoftReservedAddresses,
+		)...,
+	)
+
+	blockedAddressSet := buildAddressSet(configuration.BlockedAddresses)
+	overlapAddressSet := make(map[uint8]struct{})
+
+	for _, allowedAddress := range configuration.AllowedAddresses {
+		if _, blocked := blockedAddressSet[allowedAddress]; !blocked {
+			continue
+		}
+
+		if _, alreadyReported := overlapAddressSet[allowedAddress]; alreadyReported {
+			continue
+		}
+
+		validationErrors = append(validationErrors, ValidationError{
+			Code:    "source_address_policy.address.overlap",
+			Field:   "source_address_policy",
+			Message: fmt.Sprintf("address 0x%02X cannot be both allowed and blocked", allowedAddress),
+		})
+		overlapAddressSet[allowedAddress] = struct{}{}
+	}
 
 	return validationErrors
 }

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -190,6 +190,53 @@ func TestValidateRejectsDisabledPoliciesWithData(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsInvalidSourceAddressPolicy(t *testing.T) {
+	configuration := validConfiguration()
+	configuration.SourceAddressPolicy = SourceAddressPolicyConfig{
+		ReservationMode:       "strict",
+		AllowedAddresses:      []uint8{0x31, 0x31, 0x00},
+		BlockedAddresses:      []uint8{0x31},
+		SoftReservedAddresses: []uint8{0xFF},
+	}
+
+	expectedErrors := ValidationErrors{
+		{
+			Code:    "source_address_policy.reservation_mode.invalid",
+			Field:   "source_address_policy.reservation_mode",
+			Message: "reservation mode must be either soft or disabled",
+		},
+		{
+			Code:    "address.duplicate",
+			Field:   "source_address_policy.allowed_addresses[1]",
+			Message: "address 0x31 is duplicated",
+		},
+		{
+			Code:    "address.invalid_reserved",
+			Field:   "source_address_policy.allowed_addresses[2]",
+			Message: "address 0x00 is reserved",
+		},
+		{
+			Code:    "address.invalid_reserved",
+			Field:   "source_address_policy.soft_reserved_addresses[0]",
+			Message: "address 0xFF is reserved",
+		},
+		{
+			Code:    "source_address_policy.address.overlap",
+			Field:   "source_address_policy",
+			Message: "address 0x31 cannot be both allowed and blocked",
+		},
+	}
+
+	actualErrors, ok := Validate(configuration).(ValidationErrors)
+	if !ok {
+		t.Fatalf("expected ValidationErrors type")
+	}
+
+	if !reflect.DeepEqual(actualErrors, expectedErrors) {
+		t.Fatalf("unexpected validation errors:\nexpected: %#v\nactual: %#v", expectedErrors, actualErrors)
+	}
+}
+
 func validConfiguration() Config {
 	return Config{
 		Southbound: SouthboundConfig{
@@ -218,6 +265,9 @@ func validConfiguration() Config {
 		Emulation: EmulationConfig{
 			Enabled:                true,
 			VirtualSourceAddresses: []uint8{0x21},
+		},
+		SourceAddressPolicy: SourceAddressPolicyConfig{
+			ReservationMode: SourceAddressReservationModeSoft,
 		},
 	}
 }

--- a/internal/sourcepolicy/policy.go
+++ b/internal/sourcepolicy/policy.go
@@ -1,0 +1,150 @@
+package sourcepolicy
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	ReservationModeSoft     = "soft"
+	ReservationModeDisabled = "disabled"
+
+	DefaultSoftReservedAddress uint8 = 0x31
+)
+
+var (
+	ErrNoSourceAddressAvailable = errors.New("no source address available")
+	ErrInvalidReservationMode   = errors.New("invalid source address reservation mode")
+)
+
+type Config struct {
+	AllowedAddresses      []uint8
+	BlockedAddresses      []uint8
+	SoftReservedAddresses []uint8
+	ReservationMode       string
+}
+
+type SelectOptions struct {
+	InUseAddresses    []uint8
+	AllowSoftReserved bool
+}
+
+type Policy struct {
+	reservationMode string
+	allowedSet      map[uint8]struct{}
+	blockedSet      map[uint8]struct{}
+	softReservedSet map[uint8]struct{}
+}
+
+func NewPolicy(configuration Config) (*Policy, error) {
+	reservationMode := strings.TrimSpace(configuration.ReservationMode)
+	if reservationMode == "" {
+		reservationMode = ReservationModeSoft
+	}
+
+	switch reservationMode {
+	case ReservationModeSoft, ReservationModeDisabled:
+	default:
+		return nil, fmt.Errorf(
+			"%w: %s",
+			ErrInvalidReservationMode,
+			configuration.ReservationMode,
+		)
+	}
+
+	softReserved := uniqueSortedAddresses(configuration.SoftReservedAddresses)
+	if len(softReserved) == 0 {
+		softReserved = []uint8{DefaultSoftReservedAddress}
+	}
+
+	return &Policy{
+		reservationMode: reservationMode,
+		allowedSet:      buildAddressSet(configuration.AllowedAddresses),
+		blockedSet:      buildAddressSet(configuration.BlockedAddresses),
+		softReservedSet: buildAddressSet(softReserved),
+	}, nil
+}
+
+// SelectAddress applies deterministic source address assignment:
+// 1) candidates are normalized (sorted, unique, invalid-reserved filtered),
+// 2) allow/deny and in-use filters are applied,
+// 3) in soft reservation mode, soft-reserved addresses are avoided unless there are no alternatives.
+func (policy *Policy) SelectAddress(
+	candidates []uint8,
+	options SelectOptions,
+) (uint8, error) {
+	normalizedCandidates := uniqueSortedAddresses(candidates)
+	inUseAddressSet := buildAddressSet(options.InUseAddresses)
+	filteredCandidates := make([]uint8, 0, len(normalizedCandidates))
+
+	for _, candidate := range normalizedCandidates {
+		if len(policy.allowedSet) > 0 {
+			if _, allowed := policy.allowedSet[candidate]; !allowed {
+				continue
+			}
+		}
+
+		if _, blocked := policy.blockedSet[candidate]; blocked {
+			continue
+		}
+
+		if _, alreadyInUse := inUseAddressSet[candidate]; alreadyInUse {
+			continue
+		}
+
+		filteredCandidates = append(filteredCandidates, candidate)
+	}
+
+	if len(filteredCandidates) == 0 {
+		return 0, ErrNoSourceAddressAvailable
+	}
+
+	if policy.reservationMode == ReservationModeDisabled || options.AllowSoftReserved {
+		return filteredCandidates[0], nil
+	}
+
+	for _, candidate := range filteredCandidates {
+		if _, softReserved := policy.softReservedSet[candidate]; softReserved {
+			continue
+		}
+
+		return candidate, nil
+	}
+
+	return filteredCandidates[0], nil
+}
+
+func uniqueSortedAddresses(addresses []uint8) []uint8 {
+	if len(addresses) == 0 {
+		return nil
+	}
+
+	addressSet := buildAddressSet(addresses)
+	uniqueAddresses := make([]uint8, 0, len(addressSet))
+
+	for address := range addressSet {
+		if address == 0x00 || address == 0xFF {
+			continue
+		}
+
+		uniqueAddresses = append(uniqueAddresses, address)
+	}
+
+	sort.Slice(uniqueAddresses, func(i, j int) bool {
+		return uniqueAddresses[i] < uniqueAddresses[j]
+	})
+
+	return uniqueAddresses
+}
+
+func buildAddressSet(addresses []uint8) map[uint8]struct{} {
+	addressSet := make(map[uint8]struct{}, len(addresses))
+
+	for _, address := range addresses {
+		addressSet[address] = struct{}{}
+	}
+
+	return addressSet
+}

--- a/internal/sourcepolicy/policy_test.go
+++ b/internal/sourcepolicy/policy_test.go
@@ -1,0 +1,131 @@
+package sourcepolicy
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestPolicySoftReserve31WhenEbusdOnlinePrefersAlternative(t *testing.T) {
+	policy := mustNewPolicy(t, Config{})
+
+	selectedAddress, err := policy.SelectAddress(
+		[]uint8{0x35, 0x31},
+		SelectOptions{
+			InUseAddresses: []uint8{0x31},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected address selection success, got %v", err)
+	}
+
+	if selectedAddress != 0x35 {
+		t.Fatalf("expected selected address 0x35, got 0x%02X", selectedAddress)
+	}
+}
+
+func TestPolicySoftReserve31WhenEbusdOfflineUses31OnlyWithoutAlternatives(t *testing.T) {
+	policy := mustNewPolicy(t, Config{})
+
+	selectedAddress, err := policy.SelectAddress(
+		[]uint8{0x31, 0x40},
+		SelectOptions{},
+	)
+	if err != nil {
+		t.Fatalf("expected address selection success, got %v", err)
+	}
+
+	if selectedAddress != 0x40 {
+		t.Fatalf("expected selected address 0x40, got 0x%02X", selectedAddress)
+	}
+
+	selectedAddress, err = policy.SelectAddress(
+		[]uint8{0x31},
+		SelectOptions{},
+	)
+	if err != nil {
+		t.Fatalf("expected address selection success, got %v", err)
+	}
+
+	if selectedAddress != 0x31 {
+		t.Fatalf("expected selected address 0x31 when no alternatives exist, got 0x%02X", selectedAddress)
+	}
+}
+
+func TestPolicyExplicitAllowCanUse31WithAlternatives(t *testing.T) {
+	policy := mustNewPolicy(t, Config{})
+
+	selectedAddress, err := policy.SelectAddress(
+		[]uint8{0x31, 0x40},
+		SelectOptions{
+			AllowSoftReserved: true,
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected address selection success, got %v", err)
+	}
+
+	if selectedAddress != 0x31 {
+		t.Fatalf("expected selected address 0x31 with explicit soft-reserved allow, got 0x%02X", selectedAddress)
+	}
+}
+
+func TestPolicyAppliesAllowAndDenyFiltersDeterministically(t *testing.T) {
+	policy := mustNewPolicy(t, Config{
+		AllowedAddresses: []uint8{
+			0x31,
+			0x40,
+			0x41,
+		},
+		BlockedAddresses: []uint8{
+			0x40,
+		},
+	})
+
+	selectedAddress, err := policy.SelectAddress(
+		[]uint8{0x41, 0x40, 0x31},
+		SelectOptions{},
+	)
+	if err != nil {
+		t.Fatalf("expected address selection success, got %v", err)
+	}
+
+	if selectedAddress != 0x41 {
+		t.Fatalf("expected selected address 0x41, got 0x%02X", selectedAddress)
+	}
+}
+
+func TestPolicyRejectsInvalidReservationMode(t *testing.T) {
+	_, err := NewPolicy(Config{
+		ReservationMode: "strict",
+	})
+	if !errors.Is(err, ErrInvalidReservationMode) {
+		t.Fatalf("expected invalid reservation mode error, got %v", err)
+	}
+}
+
+func TestPolicyReturnsNoAddressAvailableWhenAllCandidatesFiltered(t *testing.T) {
+	policy := mustNewPolicy(t, Config{
+		AllowedAddresses: []uint8{0x31},
+	})
+
+	_, err := policy.SelectAddress(
+		[]uint8{0x31},
+		SelectOptions{
+			InUseAddresses: []uint8{0x31},
+		},
+	)
+	if !errors.Is(err, ErrNoSourceAddressAvailable) {
+		t.Fatalf("expected no source address available error, got %v", err)
+	}
+}
+
+func mustNewPolicy(t *testing.T, configuration Config) *Policy {
+	t.Helper()
+
+	policy, err := NewPolicy(configuration)
+	if err != nil {
+		t.Fatalf("expected policy creation success, got %v", err)
+	}
+
+	return policy
+}


### PR DESCRIPTION
## Summary
- add a configurable `internal/sourcepolicy` component for source-address selection with allow/deny filters and reservation modes
- implement deterministic soft-reserve behavior for `0x31` (avoid by default, use when no alternatives or explicitly allowed)
- add deterministic tests covering ebusd-online/offline scenarios, override behavior, and no-address outcomes
- extend config schema/validation with source-address policy fields and deterministic validation errors

Fixes #11
