### PR TITLE
M3: Address lease lifecycle + conflicts

### DIFF
--- a/internal/sourcepolicy/lease_manager.go
+++ b/internal/sourcepolicy/lease_manager.go
@@ -1,0 +1,336 @@
+package sourcepolicy
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrLeaseConflict        = errors.New("source address lease conflict")
+	ErrLeasePolicyRequired  = errors.New("source address lease policy is required")
+	ErrLeaseOwnerRequired   = errors.New("source address lease owner is required")
+	ErrInvalidLeaseDuration = errors.New("invalid source address lease duration")
+)
+
+type LeaseConflictCode string
+
+const (
+	// Lease conflict codes are stable contract values for callers and tests.
+	LeaseConflictCodeAddressInUse LeaseConflictCode = "source_address_lease.address_in_use"
+	// Lease conflict codes are stable contract values for callers and tests.
+	LeaseConflictCodeOwnerAlreadyHasLease LeaseConflictCode = "source_address_lease.owner_already_has_lease"
+	// Lease conflict codes are stable contract values for callers and tests.
+	LeaseConflictCodeOwnerLeaseMissing LeaseConflictCode = "source_address_lease.owner_lease_missing"
+	// Lease conflict codes are stable contract values for callers and tests.
+	LeaseConflictCodeOwnerLeaseExpired LeaseConflictCode = "source_address_lease.owner_lease_expired"
+)
+
+type LeaseConflictError struct {
+	Code           LeaseConflictCode
+	OwnerID        string
+	Address        uint8
+	CurrentOwnerID string
+}
+
+func (errorValue LeaseConflictError) Error() string {
+	switch errorValue.Code {
+	case LeaseConflictCodeAddressInUse:
+		return fmt.Sprintf(
+			"%s: owner %q cannot acquire address 0x%02X held by owner %q",
+			errorValue.Code,
+			errorValue.OwnerID,
+			errorValue.Address,
+			errorValue.CurrentOwnerID,
+		)
+	case LeaseConflictCodeOwnerAlreadyHasLease:
+		return fmt.Sprintf(
+			"%s: owner %q already holds address 0x%02X",
+			errorValue.Code,
+			errorValue.OwnerID,
+			errorValue.Address,
+		)
+	case LeaseConflictCodeOwnerLeaseExpired:
+		return fmt.Sprintf(
+			"%s: owner %q lease for address 0x%02X has expired",
+			errorValue.Code,
+			errorValue.OwnerID,
+			errorValue.Address,
+		)
+	default:
+		return fmt.Sprintf(
+			"%s: owner %q has no active lease",
+			errorValue.Code,
+			errorValue.OwnerID,
+		)
+	}
+}
+
+func (errorValue LeaseConflictError) Is(target error) bool {
+	return target == ErrLeaseConflict
+}
+
+type Lease struct {
+	OwnerID    string
+	Address    uint8
+	AcquiredAt time.Time
+	RenewedAt  time.Time
+	ExpiresAt  time.Time
+}
+
+type LeaseManagerOptions struct {
+	LeaseDuration  time.Duration
+	Clock          func() time.Time
+	ActivityWindow *ActivityWindow
+}
+
+type AcquireOptions struct {
+	Candidates        []uint8
+	AllowSoftReserved bool
+}
+
+type LeaseManager struct {
+	mutex          sync.Mutex
+	policy         *Policy
+	leaseDuration  time.Duration
+	clock          func() time.Time
+	activityWindow *ActivityWindow
+	leasesByOwner  map[string]Lease
+	ownerByAddress map[uint8]string
+}
+
+func NewLeaseManager(
+	policy *Policy,
+	options LeaseManagerOptions,
+) (*LeaseManager, error) {
+	if policy == nil {
+		return nil, ErrLeasePolicyRequired
+	}
+
+	if options.LeaseDuration <= 0 {
+		return nil, ErrInvalidLeaseDuration
+	}
+
+	if options.Clock == nil {
+		options.Clock = time.Now
+	}
+
+	return &LeaseManager{
+		policy:         policy,
+		leaseDuration:  options.LeaseDuration,
+		clock:          options.Clock,
+		activityWindow: options.ActivityWindow,
+		leasesByOwner:  make(map[string]Lease),
+		ownerByAddress: make(map[uint8]string),
+	}, nil
+}
+
+func (manager *LeaseManager) Acquire(
+	ownerID string,
+	options AcquireOptions,
+) (Lease, error) {
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return Lease{}, ErrLeaseOwnerRequired
+	}
+
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+
+	now := manager.clock().UTC()
+	manager.expireLocked(now)
+
+	if existingLease, found := manager.leasesByOwner[ownerID]; found {
+		return Lease{}, LeaseConflictError{
+			Code:           LeaseConflictCodeOwnerAlreadyHasLease,
+			OwnerID:        ownerID,
+			Address:        existingLease.Address,
+			CurrentOwnerID: ownerID,
+		}
+	}
+
+	normalizedCandidates := uniqueSortedAddresses(options.Candidates)
+	selectedAddress, err := manager.policy.SelectAddress(
+		normalizedCandidates,
+		SelectOptions{
+			InUseAddresses:    manager.inUseAddressesLocked(),
+			AllowSoftReserved: options.AllowSoftReserved,
+			ActivityWindow:    manager.activityWindow,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, ErrNoSourceAddressAvailable) {
+			conflictAddress, currentOwnerID, found := manager.firstAddressConflictLocked(
+				normalizedCandidates,
+			)
+			if found {
+				return Lease{}, LeaseConflictError{
+					Code:           LeaseConflictCodeAddressInUse,
+					OwnerID:        ownerID,
+					Address:        conflictAddress,
+					CurrentOwnerID: currentOwnerID,
+				}
+			}
+		}
+
+		return Lease{}, err
+	}
+
+	lease := Lease{
+		OwnerID:    ownerID,
+		Address:    selectedAddress,
+		AcquiredAt: now,
+		RenewedAt:  now,
+		ExpiresAt:  now.Add(manager.leaseDuration),
+	}
+	manager.leasesByOwner[ownerID] = lease
+	manager.ownerByAddress[lease.Address] = ownerID
+
+	return lease, nil
+}
+
+func (manager *LeaseManager) Renew(ownerID string) (Lease, error) {
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return Lease{}, ErrLeaseOwnerRequired
+	}
+
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+
+	now := manager.clock().UTC()
+	if expiredLease, expired := manager.expireOwnerIfNeededLocked(ownerID, now); expired {
+		manager.expireLocked(now)
+		return Lease{}, LeaseConflictError{
+			Code:           LeaseConflictCodeOwnerLeaseExpired,
+			OwnerID:        ownerID,
+			Address:        expiredLease.Address,
+			CurrentOwnerID: ownerID,
+		}
+	}
+
+	manager.expireLocked(now)
+	lease, found := manager.leasesByOwner[ownerID]
+	if !found {
+		return Lease{}, LeaseConflictError{
+			Code:    LeaseConflictCodeOwnerLeaseMissing,
+			OwnerID: ownerID,
+		}
+	}
+
+	lease.RenewedAt = now
+	lease.ExpiresAt = now.Add(manager.leaseDuration)
+	manager.leasesByOwner[ownerID] = lease
+
+	return lease, nil
+}
+
+func (manager *LeaseManager) Release(ownerID string) (Lease, error) {
+	ownerID = strings.TrimSpace(ownerID)
+	if ownerID == "" {
+		return Lease{}, ErrLeaseOwnerRequired
+	}
+
+	manager.mutex.Lock()
+	defer manager.mutex.Unlock()
+
+	now := manager.clock().UTC()
+	if expiredLease, expired := manager.expireOwnerIfNeededLocked(ownerID, now); expired {
+		manager.expireLocked(now)
+		return Lease{}, LeaseConflictError{
+			Code:           LeaseConflictCodeOwnerLeaseExpired,
+			OwnerID:        ownerID,
+			Address:        expiredLease.Address,
+			CurrentOwnerID: ownerID,
+		}
+	}
+
+	manager.expireLocked(now)
+	lease, found := manager.leasesByOwner[ownerID]
+	if !found {
+		return Lease{}, LeaseConflictError{
+			Code:    LeaseConflictCodeOwnerLeaseMissing,
+			OwnerID: ownerID,
+		}
+	}
+
+	delete(manager.leasesByOwner, ownerID)
+	delete(manager.ownerByAddress, lease.Address)
+
+	return lease, nil
+}
+
+func (manager *LeaseManager) Expire() []Lease {
+	manager.mutex.Lock()
+	now := manager.clock().UTC()
+	expiredLeases := manager.expireLocked(now)
+	manager.mutex.Unlock()
+
+	return expiredLeases
+}
+
+func (manager *LeaseManager) expireOwnerIfNeededLocked(
+	ownerID string,
+	now time.Time,
+) (Lease, bool) {
+	lease, found := manager.leasesByOwner[ownerID]
+	if !found || lease.ExpiresAt.After(now) {
+		return Lease{}, false
+	}
+
+	delete(manager.leasesByOwner, ownerID)
+	delete(manager.ownerByAddress, lease.Address)
+	return lease, true
+}
+
+func (manager *LeaseManager) expireLocked(now time.Time) []Lease {
+	expiredLeases := make([]Lease, 0)
+	for ownerID, lease := range manager.leasesByOwner {
+		if lease.ExpiresAt.After(now) {
+			continue
+		}
+
+		delete(manager.leasesByOwner, ownerID)
+		delete(manager.ownerByAddress, lease.Address)
+		expiredLeases = append(expiredLeases, lease)
+	}
+
+	sort.Slice(expiredLeases, func(i, j int) bool {
+		if expiredLeases[i].Address != expiredLeases[j].Address {
+			return expiredLeases[i].Address < expiredLeases[j].Address
+		}
+
+		return expiredLeases[i].OwnerID < expiredLeases[j].OwnerID
+	})
+
+	return expiredLeases
+}
+
+func (manager *LeaseManager) inUseAddressesLocked() []uint8 {
+	addresses := make([]uint8, 0, len(manager.ownerByAddress))
+	for address := range manager.ownerByAddress {
+		addresses = append(addresses, address)
+	}
+
+	sort.Slice(addresses, func(i, j int) bool {
+		return addresses[i] < addresses[j]
+	})
+
+	return addresses
+}
+
+func (manager *LeaseManager) firstAddressConflictLocked(
+	candidates []uint8,
+) (uint8, string, bool) {
+	for _, candidate := range candidates {
+		currentOwnerID, found := manager.ownerByAddress[candidate]
+		if found {
+			return candidate, currentOwnerID, true
+		}
+	}
+
+	return 0, "", false
+}

--- a/internal/sourcepolicy/lease_manager_integration_test.go
+++ b/internal/sourcepolicy/lease_manager_integration_test.go
@@ -1,0 +1,197 @@
+package sourcepolicy
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLeaseManagerConcurrentAcquireSingleAddressConflict(t *testing.T) {
+	manager := mustNewLeaseManager(
+		t,
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 30 * time.Second,
+		},
+	)
+
+	const contenders = 24
+
+	start := make(chan struct{})
+	type acquireResult struct {
+		lease Lease
+		err   error
+	}
+	results := make(chan acquireResult, contenders)
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(contenders)
+
+	for contenderIndex := 0; contenderIndex < contenders; contenderIndex++ {
+		ownerID := fmt.Sprintf("owner-%02d", contenderIndex)
+		go func(ownerID string) {
+			defer waitGroup.Done()
+			<-start
+			lease, err := manager.Acquire(
+				ownerID,
+				AcquireOptions{
+					Candidates: []uint8{0x40},
+				},
+			)
+			results <- acquireResult{
+				lease: lease,
+				err:   err,
+			}
+		}(ownerID)
+	}
+
+	close(start)
+	waitGroup.Wait()
+	close(results)
+
+	successCount := 0
+	conflictCount := 0
+
+	for result := range results {
+		if result.err == nil {
+			successCount++
+			if result.lease.Address != 0x40 {
+				t.Fatalf("expected successful lease address 0x40, got 0x%02X", result.lease.Address)
+			}
+			continue
+		}
+
+		var conflictError LeaseConflictError
+		if !errors.As(result.err, &conflictError) {
+			t.Fatalf("expected lease conflict error type, got %v", result.err)
+		}
+
+		if conflictError.Code != LeaseConflictCodeAddressInUse {
+			t.Fatalf(
+				"expected conflict code %q, got %q",
+				LeaseConflictCodeAddressInUse,
+				conflictError.Code,
+			)
+		}
+
+		if conflictError.Address != 0x40 {
+			t.Fatalf("expected conflict address 0x40, got 0x%02X", conflictError.Address)
+		}
+
+		conflictCount++
+	}
+
+	if successCount != 1 {
+		t.Fatalf("expected one successful acquisition, got %d", successCount)
+	}
+
+	if conflictCount != contenders-1 {
+		t.Fatalf(
+			"expected %d conflict acquisitions, got %d",
+			contenders-1,
+			conflictCount,
+		)
+	}
+}
+
+func TestLeaseManagerConcurrentAcquireMultiAddressContention(t *testing.T) {
+	manager := mustNewLeaseManager(
+		t,
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 30 * time.Second,
+		},
+	)
+
+	const contenders = 32
+	availableAddresses := map[uint8]struct{}{
+		0x40: {},
+		0x41: {},
+		0x42: {},
+	}
+
+	start := make(chan struct{})
+	type acquireResult struct {
+		lease Lease
+		err   error
+	}
+	results := make(chan acquireResult, contenders)
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(contenders)
+
+	for contenderIndex := 0; contenderIndex < contenders; contenderIndex++ {
+		ownerID := fmt.Sprintf("owner-%02d", contenderIndex)
+		go func(ownerID string) {
+			defer waitGroup.Done()
+			<-start
+			lease, err := manager.Acquire(
+				ownerID,
+				AcquireOptions{
+					Candidates: []uint8{0x40, 0x41, 0x42},
+				},
+			)
+			results <- acquireResult{
+				lease: lease,
+				err:   err,
+			}
+		}(ownerID)
+	}
+
+	close(start)
+	waitGroup.Wait()
+	close(results)
+
+	successAddresses := make(map[uint8]int)
+	conflictCount := 0
+
+	for result := range results {
+		if result.err == nil {
+			if _, allowed := availableAddresses[result.lease.Address]; !allowed {
+				t.Fatalf("expected successful lease in %#v, got 0x%02X", availableAddresses, result.lease.Address)
+			}
+			successAddresses[result.lease.Address]++
+			continue
+		}
+
+		var conflictError LeaseConflictError
+		if !errors.As(result.err, &conflictError) {
+			t.Fatalf("expected lease conflict error type, got %v", result.err)
+		}
+
+		if conflictError.Code != LeaseConflictCodeAddressInUse {
+			t.Fatalf(
+				"expected conflict code %q, got %q",
+				LeaseConflictCodeAddressInUse,
+				conflictError.Code,
+			)
+		}
+
+		conflictCount++
+	}
+
+	if len(successAddresses) != len(availableAddresses) {
+		t.Fatalf(
+			"expected %d successful unique leases, got %d (%#v)",
+			len(availableAddresses),
+			len(successAddresses),
+			successAddresses,
+		)
+	}
+
+	for address, count := range successAddresses {
+		if count != 1 {
+			t.Fatalf("expected address 0x%02X acquired once, got %d", address, count)
+		}
+	}
+
+	if conflictCount != contenders-len(availableAddresses) {
+		t.Fatalf(
+			"expected %d conflicts, got %d",
+			contenders-len(availableAddresses),
+			conflictCount,
+		)
+	}
+}

--- a/internal/sourcepolicy/lease_manager_test.go
+++ b/internal/sourcepolicy/lease_manager_test.go
@@ -1,0 +1,350 @@
+package sourcepolicy
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestLeaseManagerAcquireRenewReleaseLifecycle(t *testing.T) {
+	baseTime := time.Date(2026, 2, 2, 9, 30, 0, 0, time.UTC)
+	now := baseTime
+	manager := mustNewLeaseManager(
+		t,
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 5 * time.Second,
+			Clock: func() time.Time {
+				return now
+			},
+		},
+	)
+
+	acquiredLease, err := manager.Acquire(
+		"owner-a",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected acquire success, got %v", err)
+	}
+
+	if acquiredLease.Address != 0x40 {
+		t.Fatalf("expected acquired address 0x40, got 0x%02X", acquiredLease.Address)
+	}
+
+	if !acquiredLease.AcquiredAt.Equal(baseTime) {
+		t.Fatalf("expected acquired at %v, got %v", baseTime, acquiredLease.AcquiredAt)
+	}
+
+	if !acquiredLease.ExpiresAt.Equal(baseTime.Add(5 * time.Second)) {
+		t.Fatalf(
+			"expected expires at %v, got %v",
+			baseTime.Add(5*time.Second),
+			acquiredLease.ExpiresAt,
+		)
+	}
+
+	now = baseTime.Add(2 * time.Second)
+	renewedLease, err := manager.Renew("owner-a")
+	if err != nil {
+		t.Fatalf("expected renew success, got %v", err)
+	}
+
+	if !renewedLease.RenewedAt.Equal(now) {
+		t.Fatalf("expected renewed at %v, got %v", now, renewedLease.RenewedAt)
+	}
+
+	if !renewedLease.ExpiresAt.Equal(now.Add(5 * time.Second)) {
+		t.Fatalf(
+			"expected renewed expiry at %v, got %v",
+			now.Add(5*time.Second),
+			renewedLease.ExpiresAt,
+		)
+	}
+
+	releasedLease, err := manager.Release("owner-a")
+	if err != nil {
+		t.Fatalf("expected release success, got %v", err)
+	}
+
+	if releasedLease.Address != 0x40 {
+		t.Fatalf("expected released address 0x40, got 0x%02X", releasedLease.Address)
+	}
+
+	reacquiredLease, err := manager.Acquire(
+		"owner-a",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected reacquire success, got %v", err)
+	}
+
+	if reacquiredLease.Address != 0x40 {
+		t.Fatalf("expected reacquired address 0x40, got 0x%02X", reacquiredLease.Address)
+	}
+}
+
+func TestLeaseManagerAcquireAddressConflictCode(t *testing.T) {
+	manager := mustNewLeaseManager(
+		t,
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 30 * time.Second,
+		},
+	)
+
+	_, err := manager.Acquire(
+		"owner-a",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected first acquire success, got %v", err)
+	}
+
+	_, err = manager.Acquire(
+		"owner-b",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if !errors.Is(err, ErrLeaseConflict) {
+		t.Fatalf("expected lease conflict error, got %v", err)
+	}
+
+	var conflictError LeaseConflictError
+	if !errors.As(err, &conflictError) {
+		t.Fatalf("expected lease conflict error type, got %T", err)
+	}
+
+	if conflictError.Code != LeaseConflictCodeAddressInUse {
+		t.Fatalf(
+			"expected conflict code %q, got %q",
+			LeaseConflictCodeAddressInUse,
+			conflictError.Code,
+		)
+	}
+
+	if conflictError.Address != 0x40 {
+		t.Fatalf("expected conflict address 0x40, got 0x%02X", conflictError.Address)
+	}
+}
+
+func TestLeaseManagerOwnerConflictCodes(t *testing.T) {
+	baseTime := time.Date(2026, 2, 2, 10, 0, 0, 0, time.UTC)
+	now := baseTime
+	manager := mustNewLeaseManager(
+		t,
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 3 * time.Second,
+			Clock: func() time.Time {
+				return now
+			},
+		},
+	)
+
+	_, err := manager.Acquire(
+		"owner-a",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected acquire success, got %v", err)
+	}
+
+	_, err = manager.Acquire(
+		"owner-a",
+		AcquireOptions{
+			Candidates: []uint8{0x41},
+		},
+	)
+	assertLeaseConflictCode(t, err, LeaseConflictCodeOwnerAlreadyHasLease)
+
+	_, err = manager.Renew("owner-missing")
+	assertLeaseConflictCode(t, err, LeaseConflictCodeOwnerLeaseMissing)
+
+	_, err = manager.Release("owner-missing")
+	assertLeaseConflictCode(t, err, LeaseConflictCodeOwnerLeaseMissing)
+
+	now = now.Add(4 * time.Second)
+
+	_, err = manager.Renew("owner-a")
+	assertLeaseConflictCode(t, err, LeaseConflictCodeOwnerLeaseExpired)
+
+	_, err = manager.Release("owner-a")
+	assertLeaseConflictCode(t, err, LeaseConflictCodeOwnerLeaseMissing)
+}
+
+func TestLeaseManagerExpireRemovesExpiredLeases(t *testing.T) {
+	baseTime := time.Date(2026, 2, 2, 11, 0, 0, 0, time.UTC)
+	now := baseTime
+	manager := mustNewLeaseManager(
+		t,
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 5 * time.Second,
+			Clock: func() time.Time {
+				return now
+			},
+		},
+	)
+
+	_, err := manager.Acquire(
+		"owner-a",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected acquire owner-a success, got %v", err)
+	}
+
+	now = now.Add(2 * time.Second)
+	_, err = manager.Acquire(
+		"owner-b",
+		AcquireOptions{
+			Candidates: []uint8{0x41},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected acquire owner-b success, got %v", err)
+	}
+
+	now = baseTime.Add(5 * time.Second)
+	expiredLeases := manager.Expire()
+	if len(expiredLeases) != 1 {
+		t.Fatalf("expected one expired lease at first boundary, got %d", len(expiredLeases))
+	}
+
+	if expiredLeases[0].OwnerID != "owner-a" {
+		t.Fatalf("expected owner-a to expire first, got %q", expiredLeases[0].OwnerID)
+	}
+
+	now = baseTime.Add(7 * time.Second)
+	expiredLeases = manager.Expire()
+	if len(expiredLeases) != 1 {
+		t.Fatalf("expected one expired lease at second boundary, got %d", len(expiredLeases))
+	}
+
+	if expiredLeases[0].OwnerID != "owner-b" {
+		t.Fatalf("expected owner-b to expire second, got %q", expiredLeases[0].OwnerID)
+	}
+
+	_, err = manager.Acquire(
+		"owner-c",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if err != nil {
+		t.Fatalf("expected acquire after expiration success, got %v", err)
+	}
+}
+
+func TestLeaseConflictCodesRemainStable(t *testing.T) {
+	expectedCodes := map[LeaseConflictCode]string{
+		LeaseConflictCodeAddressInUse:         "source_address_lease.address_in_use",
+		LeaseConflictCodeOwnerAlreadyHasLease: "source_address_lease.owner_already_has_lease",
+		LeaseConflictCodeOwnerLeaseMissing:    "source_address_lease.owner_lease_missing",
+		LeaseConflictCodeOwnerLeaseExpired:    "source_address_lease.owner_lease_expired",
+	}
+
+	for code, expected := range expectedCodes {
+		if string(code) != expected {
+			t.Fatalf("expected stable code %q, got %q", expected, code)
+		}
+	}
+}
+
+func TestLeaseManagerRejectsInvalidInputs(t *testing.T) {
+	_, err := NewLeaseManager(
+		nil,
+		LeaseManagerOptions{
+			LeaseDuration: 5 * time.Second,
+		},
+	)
+	if !errors.Is(err, ErrLeasePolicyRequired) {
+		t.Fatalf("expected lease policy required error, got %v", err)
+	}
+
+	_, err = NewLeaseManager(
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 0,
+		},
+	)
+	if !errors.Is(err, ErrInvalidLeaseDuration) {
+		t.Fatalf("expected invalid lease duration error, got %v", err)
+	}
+
+	manager := mustNewLeaseManager(
+		t,
+		mustNewPolicy(t, Config{}),
+		LeaseManagerOptions{
+			LeaseDuration: 5 * time.Second,
+		},
+	)
+
+	_, err = manager.Acquire(
+		" ",
+		AcquireOptions{
+			Candidates: []uint8{0x40},
+		},
+	)
+	if !errors.Is(err, ErrLeaseOwnerRequired) {
+		t.Fatalf("expected lease owner required error, got %v", err)
+	}
+
+	_, err = manager.Renew(" ")
+	if !errors.Is(err, ErrLeaseOwnerRequired) {
+		t.Fatalf("expected lease owner required error, got %v", err)
+	}
+
+	_, err = manager.Release("")
+	if !errors.Is(err, ErrLeaseOwnerRequired) {
+		t.Fatalf("expected lease owner required error, got %v", err)
+	}
+}
+
+func mustNewLeaseManager(
+	t *testing.T,
+	policy *Policy,
+	options LeaseManagerOptions,
+) *LeaseManager {
+	t.Helper()
+
+	manager, err := NewLeaseManager(policy, options)
+	if err != nil {
+		t.Fatalf("expected lease manager creation success, got %v", err)
+	}
+
+	return manager
+}
+
+func assertLeaseConflictCode(
+	t *testing.T,
+	err error,
+	expectedCode LeaseConflictCode,
+) {
+	t.Helper()
+
+	if !errors.Is(err, ErrLeaseConflict) {
+		t.Fatalf("expected lease conflict error, got %v", err)
+	}
+
+	var conflictError LeaseConflictError
+	if !errors.As(err, &conflictError) {
+		t.Fatalf("expected lease conflict error type, got %T", err)
+	}
+
+	if conflictError.Code != expectedCode {
+		t.Fatalf("expected conflict code %q, got %q", expectedCode, conflictError.Code)
+	}
+}


### PR DESCRIPTION
Fixes #13

## Summary
- add `internal/sourcepolicy.LeaseManager` with deterministic lease lifecycle operations: `Acquire`, `Renew`, `Release`, and `Expire`
- add stable typed lease conflict codes via `LeaseConflictCode` and `LeaseConflictError`, including comments that mark contract stability
- integrate lease admission with existing source-address policy + activity-window filtering, while reporting address-in-use conflicts for active leases
- add unit and integration coverage for lifecycle behavior, conflict taxonomy, expiration boundaries, and concurrent acquisition contention

## Tests Run
- `gofmt -w $(rg --files -g '*.go')`
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/terminology-gate.sh`