### PR TITLE
M3: Docs gate sync for source policy + leases

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -13,19 +13,21 @@
 - `internal/northbound/ens`: ENS northbound multi-session listener.
 - `internal/session`: session registry, lifecycle hooks, and bounded per-session queues.
 - `internal/scheduler/write`: adaptive write scheduler with starvation guard.
+- `internal/sourcepolicy`: source-address selection policy, recent-activity guard, and owner lease lifecycle.
 - `internal/domain/downstream`: downstream frame contracts and client interface.
 - `internal/domain/upstream`: upstream message contracts and client interface.
 - `internal/domain/routing`: routing contract between downstream and upstream domains.
 - `internal/proxy`: service orchestration for routing and publication.
 
-## Runtime path (M2)
+## Runtime path (M3)
 
 1. Initialize one southbound owner connection (ENH or ENS) to the adapter.
 2. Start northbound listeners (ENH and/or ENS) that accept concurrent client sessions.
-3. Register client sessions in `internal/session.Manager` with stable IDs and bounded inbound/outbound queues.
-4. Decode per-session transport frames and enqueue/dequeue `downstream.Frame` values per session.
-5. Build scheduler candidates from per-session queue depth and choose next writer via `AdaptiveScheduler`.
-6. Route selected frames through domain/proxy orchestration toward upstream publication.
+3. Acquire source-address leases through `internal/sourcepolicy.LeaseManager` using deterministic `Policy` selection.
+4. Register client sessions in `internal/session.Manager` with stable IDs and bounded inbound/outbound queues.
+5. Decode per-session transport frames and enqueue/dequeue `downstream.Frame` values per session.
+6. Build scheduler candidates from per-session queue depth and choose next writer via `AdaptiveScheduler`.
+7. Route selected frames through domain/proxy orchestration toward upstream publication.
 
 ## Session behavior
 
@@ -46,6 +48,22 @@
 
 - `AdaptiveScheduler` prioritizes queue pressure (`QueueDepth`) and uses deterministic tie-breaking.
 - Starvation guard (`Options.StarvationAfter`) forces service for stale sessions under sustained skewed load.
+
+## Source-address policy behavior
+
+- `Policy` normalizes candidate source addresses (sorted, unique, filtered for `0x00`/`0xFF`) before selection.
+- Selection filters candidates by allow-list, block-list, in-use addresses, and optional recent-activity guard.
+- In `soft` reservation mode, soft-reserved addresses (default includes `0x31`) are avoided unless no alternatives remain.
+- `AllowSoftReserved` or `ReservationMode=disabled` allows direct selection of soft-reserved candidates.
+- If all candidates are filtered by recent activity, selection returns `ErrRecentlyActiveAddress`; otherwise it returns `ErrNoSourceAddressAvailable`.
+
+## Lease lifecycle and conflict outcomes
+
+- Lease lifecycle operations are `Acquire`, `Renew`, `Release`, and `Expire`, serialized under one manager mutex.
+- `Acquire` rejects empty owner IDs, removes expired leases first, then creates a lease with `AcquiredAt`, `RenewedAt`, and `ExpiresAt`.
+- `Renew` extends `ExpiresAt` for an active lease; `Release` removes owner/address ownership mappings.
+- `Expire` removes leases where `ExpiresAt <= now` and returns expired leases sorted by address, then owner ID.
+- Conflict outcomes are stable contract codes: `source_address_lease.address_in_use`, `source_address_lease.owner_already_has_lease`, `source_address_lease.owner_lease_missing`, and `source_address_lease.owner_lease_expired`.
 
 ## Terminology policy
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -24,7 +24,12 @@
 - Session manager tests must cover bounded queue backpressure behavior, overflow error taxonomy (`ErrInboundBackpressure`, `ErrOutboundBackpressure`, `ErrQueueFull`), and deterministic rejected/dropped metric counters.
 - Scheduler tests must cover deterministic selection behavior, fairness under balanced load, and starvation-guard behavior under skewed sustained load.
 - Scheduler concurrency tests must remain race-safe and verify valid session selection under concurrent `Select` calls.
-- Prefer deterministic assertions (stable counters/order) over timing-sensitive assertions.
+- Source policy tests must cover deterministic allow/block/in-use filtering and soft-reserve behavior for `0x31` with and without `AllowSoftReserved`.
+- Activity-window tests must verify the exact timing boundary (`window` is exclusive), plus non-trackable address handling (`0x00`, `0xFF`).
+- Lease manager tests must cover `Acquire`/`Renew`/`Release`/`Expire` lifecycle behavior, including `ExpiresAt <= now` boundary behavior.
+- Lease conflict tests must assert stable conflict codes for address contention, duplicate owner acquire, missing owner lease, and expired owner lease.
+- Lease concurrency tests must cover simultaneous lease contention (single address and multi-address pools) and assert one active winner per address.
+- Prefer deterministic assertions (stable counters/order, injected clocks) over sleep-based timing assertions.
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,16 @@ eBUS adapter proxy service with southbound transport drivers and northbound mult
   - `internal/northbound/enh`: concurrent ENH listener sessions with metrics and lifecycle hooks.
   - `internal/northbound/ens`: concurrent ENS listener sessions with metrics and lifecycle hooks.
 - Domain contracts and proxy orchestration in `internal/domain/*` and `internal/proxy`.
+- Source-address policy and lease lifecycle components in `internal/sourcepolicy`.
 - CI workflow that runs tests, vet, and terminology checks.
 - Repository guardrail and architecture documents.
 
-## Runtime shape (M2)
+## Runtime shape (M3)
 
 - One southbound owner connection to the physical adapter (ENH or ENS).
 - Multiple concurrent northbound client sessions (ENH and ENS listeners).
+- `internal/sourcepolicy.Policy` applies deterministic source-address selection filters before lease assignment.
+- `internal/sourcepolicy.LeaseManager` enforces one active lease per owner and one owner per source address.
 - Listener sessions decode transport frames and pass them to proxy domain handling.
 - `internal/session.Manager` tracks session lifecycle, stable session identity, and bounded per-session queues.
 - `internal/scheduler/write.AdaptiveScheduler` selects the next writer from queue-pressure candidates and applies starvation protection.
@@ -31,6 +34,15 @@ eBUS adapter proxy service with southbound transport drivers and northbound mult
 - Disconnect (`Unregister`) clears queued frames for that session and counts them as dropped.
 - `internal/session.Session.QueueMetrics` and `internal/session.Manager.Metrics()` expose deterministic counters:
   `RejectedInbound`, `RejectedOutbound`, `DroppedInbound`, `DroppedOutbound`.
+
+## Source-address policy and lease semantics (M3)
+
+- Candidate addresses are normalized (sorted, unique) and invalid reserved values (`0x00`, `0xFF`) are dropped.
+- Selection applies allow-list, block-list, in-use, and recent-activity filters in deterministic order.
+- Default reservation mode is `soft` with `0x31` soft-reserved; the policy avoids soft-reserved addresses when alternatives exist.
+- Soft-reserved candidates are still selectable when no alternatives remain, `ReservationMode` is `disabled`, or `AllowSoftReserved` is set.
+- Recent-activity guard blocks addresses observed within the configured activity window for new leases; at the exact window boundary the address becomes eligible again.
+- When every candidate is filtered only by recent activity, selection returns `ErrRecentlyActiveAddress`; otherwise exhaustion returns `ErrNoSourceAddressAvailable`.
 
 ## Terminology policy
 


### PR DESCRIPTION
## Summary
- sync README with source-address policy behavior, soft reserve semantics, and recent-activity guard
- document lease lifecycle (`acquire`/`renew`/`release`/`expire`) and conflict outcomes in architecture docs
- update testing conventions for timing boundaries and concurrent lease contention

## Validation
- gofmt -w $(rg --files -g '*.go')
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- ./scripts/terminology-gate.sh

Fixes #39