### PR TITLE
Sync docs for M4 integration path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,6 +38,16 @@
 5. Compare request/response pairs byte-for-byte and emit stable pass/fail lines.
 6. Report final `RESULT: PASS|FAIL` to prove or reject config-only migration behavior.
 
+## Integration runtime flow and readiness markers (M4)
+
+1. Run issue #14 harness (`scripts/run-ebusd-compat-harness.sh`) to prove config-only direct-to-proxy endpoint switch for ebusd commands.
+2. Treat `RESULT: PASS ...` as readiness for compatibility; `RESULT: FAIL ...` is a hard stop for integration rollout.
+3. Run issue #15 gateway smoke (`scripts/run-gateway-direct-proxy-smoke.sh --profile <enh|ens>`) against `../helianthus-ebusgateway` to validate proxy transport profile wiring.
+4. Treat `PASS: gateway path readiness profile=<enh|ens> endpoint=<enh|ens>://...` as gateway readiness; the corresponding `FAIL: gateway path readiness ...` line is the deterministic failure contract.
+5. Run issue #16 add-on linkage checks via `../helianthus-ha-addon/scripts/smoke_addon_checklist.py` and require checklist markers `[PASS] CHECK_LOG_PROXY_PROFILE :: ...` and `[PASS] CHECK_LOG_PROXY_ENDPOINT :: ...`.
+6. Run issue #17 dual-topology smoke (`scripts/run-ha-integration-dual-topology-smoke.sh`) against `../helianthus-ha-integration` to verify coexistence path (`ebusd` endpoint + proxy endpoint).
+7. Treat `[PASS] CHECK_DUAL_TOPOLOGY_PATH :: ...`, `PASS: gateway readiness dual-topology path ...`, and `OVERALL PASS` as the readiness marker set; any `[FAIL] CHECK_DUAL_TOPOLOGY_PATH :: ...` or wrapper `FAIL: gateway readiness dual-topology path ...` line is gate-failing.
+
 ## Session behavior
 
 - Northbound listeners expose deterministic lifecycle hooks: connect, disconnect, error.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -32,6 +32,14 @@
 - Compatibility harness tests must prove identical direct-vs-proxy request/response exchanges for representative ebusd command sets under deterministic local topology.
 - Prefer deterministic assertions (stable counters/order, injected clocks) over sleep-based timing assertions.
 
+## M4 smoke marker expectations
+
+- `scripts/run-ebusd-compat-harness.sh` must leave `.verify/issue14/ebusd-compat-harness.log` with deterministic terminal marker `RESULT: PASS ...` on success (or `RESULT: FAIL ...` on mismatch).
+- `scripts/run-gateway-direct-proxy-smoke.sh` must leave `.verify/issue15/gateway-smoke-<profile>.log` and emit deterministic readiness lines `PASS: gateway path readiness profile=<enh|ens> endpoint=<enh|ens>://...` or `FAIL: gateway path readiness ...`.
+- HA add-on linkage checks (issue #16) run in `../helianthus-ha-addon/scripts/smoke_addon_checklist.py`; proxy topology validation must assert `[PASS] CHECK_LOG_PROXY_PROFILE :: ...` and `[PASS] CHECK_LOG_PROXY_ENDPOINT :: ...`.
+- `scripts/run-ha-integration-dual-topology-smoke.sh` must leave `.verify/issue17/ha-dual-topology-<profile>.log`, parse `CHECK_DUAL_TOPOLOGY_PATH`, and emit deterministic wrapper markers `PASS|FAIL: gateway readiness dual-topology path ...`.
+- Dual-topology verification must require both marker layers: checklist marker (`[PASS] CHECK_DUAL_TOPOLOGY_PATH :: ...`) and overall marker (`OVERALL PASS`) from `../helianthus-ha-integration/scripts/run-ha-dual-topology-smoke.sh`.
+
 ## Terminology
 
 - Preferred terms: `initiator`, `target`, `allow`, `block`.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ eBUS adapter proxy service with southbound transport drivers and northbound mult
 - Recent-activity guard blocks addresses observed within the configured activity window for new leases; at the exact window boundary the address becomes eligible again.
 - When every candidate is filtered only by recent activity, selection returns `ErrRecentlyActiveAddress`; otherwise exhaustion returns `ErrNoSourceAddressAvailable`.
 
+## M4 integration path map (#14/#15/#16/#17)
+
+- Issue #14 (`scripts/run-ebusd-compat-harness.sh`): validates config-only ebusd migration and emits `RESULT: PASS|FAIL` in `.verify/issue14/ebusd-compat-harness.log`.
+- Issue #15 (`scripts/run-gateway-direct-proxy-smoke.sh`): validates gateway `enh://`/`ens://` direct-proxy transport and emits `PASS|FAIL: gateway path readiness profile=...`.
+- Issue #16 (HA add-on linkage): aligns `proxy_profile` + `proxy_endpoint` semantics with `../helianthus-ha-addon/README.md` and `../helianthus-ha-addon/SMOKE_RUNBOOK.md`.
+- Issue #17 (`scripts/run-ha-integration-dual-topology-smoke.sh`): validates coexistence (`ebusd` + adapter-proxy) and requires `CHECK_DUAL_TOPOLOGY_PATH` readiness markers.
+
 ## ebusd compatibility harness (M4)
 
 - Goal: prove config-only migration for ebusd clients by switching only `host:port` from direct adapter endpoint to proxy endpoint.
@@ -83,9 +90,7 @@ RESULT: FAIL (proxy responses diverge from direct endpoint)
 - Smoke profile templates for gateway live in:
   - `profiles/gateway-direct-proxy/agent-local.enh.md`
   - `profiles/gateway-direct-proxy/agent-local.ens.md`
-- HA add-on proxy topology profile references (aligned with `d3vi1/helianthus-ha-addon#30` / PR `#31`) live in:
-  - `../helianthus-ha-addon/README.md` (transition config includes `proxy_profile` and `proxy_endpoint`)
-  - `../helianthus-ha-addon/SMOKE_RUNBOOK.md` (proxy topology + deterministic smoke checklist)
+- HA add-on profile linkage details are tracked in issue #16 section below.
 - Cross-repo smoke runner:
   - `scripts/run-gateway-direct-proxy-smoke.sh`
 - Dual-topology smoke notes:
@@ -140,6 +145,25 @@ Deterministic failure shape for gateway path readiness:
 FAIL: gateway path readiness profile=<enh|ens> endpoint=<enh|ens>://127.0.0.1:<port> (see <repo>/.verify/issue15/gateway-smoke-<profile>.log)
 ```
 
+## HA add-on proxy profile linkage (M4, issue #16)
+
+- Coordination target: `d3vi1/helianthus-ha-addon#30` / PR `#31`.
+- Cross-repo profile configuration and smoke runbook live in:
+  - `../helianthus-ha-addon/README.md`
+  - `../helianthus-ha-addon/SMOKE_RUNBOOK.md`
+- Deterministic checklist markers must include:
+  - `[PASS] CHECK_LOG_PROXY_PROFILE :: ...`
+  - `[PASS] CHECK_LOG_PROXY_ENDPOINT :: ...`
+
+Cross-repo setup:
+
+```bash
+cd ../helianthus-ha-addon
+git checkout main
+git pull --ff-only origin main
+cd ../helianthus-ebus-adapter-proxy
+```
+
 HA add-on proxy marker checklist (ENH example):
 
 ```bash
@@ -156,8 +180,8 @@ python3 scripts/smoke_addon_checklist.py \
 Expected proxy marker checks in checklist output:
 
 ```text
-PASS CHECK_LOG_PROXY_PROFILE ...
-PASS CHECK_LOG_PROXY_ENDPOINT ...
+[PASS] CHECK_LOG_PROXY_PROFILE :: ...
+[PASS] CHECK_LOG_PROXY_ENDPOINT :: ...
 ```
 
 ## HA integration dual-topology smoke path (M4, issue #17)


### PR DESCRIPTION
## Summary
- sync M4 docs gate coverage across integration path issues #14/#15/#16/#17
- update README with explicit issue #16 HA add-on profile linkage and cross-repo pointers
- document M4 integration runtime readiness markers in ARCHITECTURE and deterministic marker expectations in CONVENTIONS

Fixes #45

## Tests run
- gofmt -w internal/session/manager.go
internal/session/manager_test.go
internal/northbound/ens/listener.go
internal/northbound/ens/listener_test.go
internal/northbound/enh/listener.go
internal/northbound/enh/listener_test.go
internal/domain/upstream/upstream.go
internal/domain/routing/routing.go
internal/domain/downstream/downstream.go
internal/southbound/ens/driver_test.go
internal/southbound/ens/codec.go
internal/southbound/ens/driver.go
internal/southbound/ens/codec_test.go
internal/southbound/enh/driver_test.go
internal/southbound/enh/codec.go
internal/southbound/enh/driver.go
internal/southbound/enh/codec_test.go
internal/sourcepolicy/activity_window_test.go
internal/sourcepolicy/lease_manager_test.go
internal/sourcepolicy/lease_manager.go
internal/sourcepolicy/lease_manager_integration_test.go
internal/sourcepolicy/policy.go
internal/sourcepolicy/activity_window.go
internal/sourcepolicy/policy_test.go
internal/scheduler/write/adaptive.go
internal/scheduler/write/adaptive_test.go
internal/admin/status.go
internal/admin/http.go
internal/admin/http_test.go
internal/config/validation_test.go
internal/config/validation.go
internal/config/config.go
internal/proxy/service_test.go
internal/proxy/service.go
internal/compat/ebusd/harness_test.go
internal/compat/ebusd/harness.go
cmd/helianthus-ebus-adapter-proxy/main.go
cmd/ebusd-compat-harness/main.go
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- ./scripts/terminology-gate.sh
