### PR TITLE
Add shared arbitration path for emulated and pass-through writes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,7 +12,7 @@
 - `internal/northbound/enh`: ENH northbound multi-session listener.
 - `internal/northbound/ens`: ENS northbound multi-session listener.
 - `internal/session`: session registry, lifecycle hooks, and bounded per-session queues.
-- `internal/scheduler/write`: adaptive write scheduler with starvation guard.
+- `internal/scheduler/write`: adaptive write scheduler with starvation guard and shared arbitration path for pass-through + emulated writes.
 - `internal/sourcepolicy`: source-address selection policy, recent-activity guard, and owner lease lifecycle.
 - `internal/domain/downstream`: downstream frame contracts and client interface.
 - `internal/domain/upstream`: upstream message contracts and client interface.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ eBUS adapter proxy service with southbound transport drivers and northbound mult
   - `internal/northbound/enh`: concurrent ENH listener sessions with metrics and lifecycle hooks.
   - `internal/northbound/ens`: concurrent ENS listener sessions with metrics and lifecycle hooks.
 - Domain contracts and proxy orchestration in `internal/domain/*` and `internal/proxy`.
+- Shared write arbitration path in `internal/scheduler/write` for deterministic ordering across pass-through and emulated writes.
 - Source-address policy and lease lifecycle components in `internal/sourcepolicy`.
 - Emulated target profile registry in `internal/emulation/targets` with a built-in VR90 profile (disabled by default), runtime enable/disable, and deterministic route selection.
 - CI workflow that runs tests, vet, and terminology checks.

--- a/internal/scheduler/write/shared_path.go
+++ b/internal/scheduler/write/shared_path.go
@@ -1,0 +1,137 @@
+package writescheduler
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+var (
+	ErrArbitrationIDRequired = errors.New("arbitration id is required")
+	ErrWriteModeUnsupported  = errors.New("write mode is unsupported")
+)
+
+type WriteMode string
+
+const (
+	WriteModePassThrough WriteMode = "pass_through"
+	WriteModeEmulated    WriteMode = "emulated"
+)
+
+type WriteEnvelope struct {
+	ArbitrationID uint64
+	Mode          WriteMode
+	Frame         downstream.Frame
+}
+
+type SharedArbitrationPath struct {
+	mutex     sync.Mutex
+	scheduler *AdaptiveScheduler
+	queues    map[uint64][]WriteEnvelope
+}
+
+func NewSharedArbitrationPath(scheduler *AdaptiveScheduler) *SharedArbitrationPath {
+	if scheduler == nil {
+		scheduler = NewAdaptiveScheduler(Options{})
+	}
+
+	return &SharedArbitrationPath{
+		scheduler: scheduler,
+		queues:    make(map[uint64][]WriteEnvelope),
+	}
+}
+
+func (path *SharedArbitrationPath) EnqueuePassThrough(
+	arbitrationID uint64,
+	frame downstream.Frame,
+) error {
+	return path.enqueue(WriteEnvelope{
+		ArbitrationID: arbitrationID,
+		Mode:          WriteModePassThrough,
+		Frame:         frame,
+	})
+}
+
+func (path *SharedArbitrationPath) EnqueueEmulated(
+	arbitrationID uint64,
+	frame downstream.Frame,
+) error {
+	return path.enqueue(WriteEnvelope{
+		ArbitrationID: arbitrationID,
+		Mode:          WriteModeEmulated,
+		Frame:         frame,
+	})
+}
+
+func (path *SharedArbitrationPath) NextWrite() (WriteEnvelope, bool) {
+	path.mutex.Lock()
+	defer path.mutex.Unlock()
+
+	candidates := make([]Candidate, 0, len(path.queues))
+	for arbitrationID, queue := range path.queues {
+		if len(queue) == 0 {
+			continue
+		}
+
+		candidates = append(candidates, Candidate{
+			SessionID:  arbitrationID,
+			QueueDepth: len(queue),
+		})
+	}
+
+	selectedArbitrationID, ok := path.scheduler.Select(candidates)
+	if !ok {
+		return WriteEnvelope{}, false
+	}
+
+	queue := path.queues[selectedArbitrationID]
+	nextWrite := queue[0]
+
+	if len(queue) == 1 {
+		delete(path.queues, selectedArbitrationID)
+	} else {
+		path.queues[selectedArbitrationID] = queue[1:]
+	}
+
+	return cloneWriteEnvelope(nextWrite), true
+}
+
+func (path *SharedArbitrationPath) Pending(arbitrationID uint64) int {
+	path.mutex.Lock()
+	pending := len(path.queues[arbitrationID])
+	path.mutex.Unlock()
+
+	return pending
+}
+
+func (path *SharedArbitrationPath) enqueue(write WriteEnvelope) error {
+	if write.ArbitrationID == 0 {
+		return ErrArbitrationIDRequired
+	}
+
+	if write.Mode != WriteModePassThrough && write.Mode != WriteModeEmulated {
+		return ErrWriteModeUnsupported
+	}
+
+	path.mutex.Lock()
+	path.queues[write.ArbitrationID] = append(
+		path.queues[write.ArbitrationID],
+		cloneWriteEnvelope(write),
+	)
+	path.mutex.Unlock()
+
+	return nil
+}
+
+func cloneWriteEnvelope(write WriteEnvelope) WriteEnvelope {
+	return WriteEnvelope{
+		ArbitrationID: write.ArbitrationID,
+		Mode:          write.Mode,
+		Frame: downstream.Frame{
+			Address: write.Frame.Address,
+			Command: write.Frame.Command,
+			Payload: append([]byte(nil), write.Frame.Payload...),
+		},
+	}
+}

--- a/internal/scheduler/write/shared_path_test.go
+++ b/internal/scheduler/write/shared_path_test.go
@@ -1,0 +1,204 @@
+package writescheduler
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	sessionmanager "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/session"
+)
+
+func TestSharedArbitrationPathRejectsInvalidWrites(t *testing.T) {
+	path := NewSharedArbitrationPath(NewAdaptiveScheduler(Options{StarvationAfter: 4}))
+
+	err := path.EnqueuePassThrough(0, downstream.Frame{Command: 0x01})
+	if !errors.Is(err, ErrArbitrationIDRequired) {
+		t.Fatalf("expected arbitration id required error, got %v", err)
+	}
+
+	err = path.enqueue(WriteEnvelope{
+		ArbitrationID: 1,
+		Mode:          WriteMode("unknown"),
+		Frame:         downstream.Frame{Command: 0x02},
+	})
+	if !errors.Is(err, ErrWriteModeUnsupported) {
+		t.Fatalf("expected unsupported write mode error, got %v", err)
+	}
+}
+
+func TestSharedArbitrationPathIntegrationOrderingGuaranteeMixedModes(t *testing.T) {
+	path := NewSharedArbitrationPath(NewAdaptiveScheduler(Options{StarvationAfter: 5}))
+
+	if err := path.EnqueuePassThrough(
+		10,
+		downstream.Frame{Command: 0xA0, Payload: []byte{0x10}},
+	); err != nil {
+		t.Fatalf("expected pass-through enqueue success, got %v", err)
+	}
+	if err := path.EnqueueEmulated(
+		10,
+		downstream.Frame{Command: 0xA1, Payload: []byte{0x11}},
+	); err != nil {
+		t.Fatalf("expected emulated enqueue success, got %v", err)
+	}
+	if err := path.EnqueueEmulated(
+		20,
+		downstream.Frame{Command: 0xB0, Payload: []byte{0x20}},
+	); err != nil {
+		t.Fatalf("expected emulated enqueue success, got %v", err)
+	}
+	if err := path.EnqueuePassThrough(
+		20,
+		downstream.Frame{Command: 0xB1, Payload: []byte{0x21}},
+	); err != nil {
+		t.Fatalf("expected pass-through enqueue success, got %v", err)
+	}
+
+	want := []WriteEnvelope{
+		{ArbitrationID: 10, Mode: WriteModePassThrough, Frame: downstream.Frame{Command: 0xA0, Payload: []byte{0x10}}},
+		{ArbitrationID: 20, Mode: WriteModeEmulated, Frame: downstream.Frame{Command: 0xB0, Payload: []byte{0x20}}},
+		{ArbitrationID: 10, Mode: WriteModeEmulated, Frame: downstream.Frame{Command: 0xA1, Payload: []byte{0x11}}},
+		{ArbitrationID: 20, Mode: WriteModePassThrough, Frame: downstream.Frame{Command: 0xB1, Payload: []byte{0x21}}},
+	}
+
+	for index, expectedWrite := range want {
+		write, ok := path.NextWrite()
+		if !ok {
+			t.Fatalf("expected write #%d to be available", index)
+		}
+
+		if !reflect.DeepEqual(write, expectedWrite) {
+			t.Fatalf("write #%d mismatch:\nexpected: %#v\nactual: %#v", index, expectedWrite, write)
+		}
+	}
+
+	if _, ok := path.NextWrite(); ok {
+		t.Fatalf("expected no writes after queue drain")
+	}
+}
+
+func TestSharedArbitrationPathIntegrationDeterministicControlSequence(t *testing.T) {
+	wantSequence := []WriteEnvelope{
+		{ArbitrationID: 1, Mode: WriteModePassThrough, Frame: downstream.Frame{Command: 0x11, Payload: []byte{0x01}}},
+		{ArbitrationID: 2, Mode: WriteModeEmulated, Frame: downstream.Frame{Command: 0x21, Payload: []byte{0x02}}},
+		{ArbitrationID: 1, Mode: WriteModeEmulated, Frame: downstream.Frame{Command: 0x12, Payload: []byte{0x03}}},
+		{ArbitrationID: 2, Mode: WriteModePassThrough, Frame: downstream.Frame{Command: 0x22, Payload: []byte{0x04}}},
+	}
+
+	for iteration := 0; iteration < 50; iteration++ {
+		path := NewSharedArbitrationPath(NewAdaptiveScheduler(Options{StarvationAfter: 4}))
+
+		enqueues := []WriteEnvelope{
+			{ArbitrationID: 1, Mode: WriteModePassThrough, Frame: downstream.Frame{Command: 0x11, Payload: []byte{0x01}}},
+			{ArbitrationID: 1, Mode: WriteModeEmulated, Frame: downstream.Frame{Command: 0x12, Payload: []byte{0x03}}},
+			{ArbitrationID: 2, Mode: WriteModeEmulated, Frame: downstream.Frame{Command: 0x21, Payload: []byte{0x02}}},
+			{ArbitrationID: 2, Mode: WriteModePassThrough, Frame: downstream.Frame{Command: 0x22, Payload: []byte{0x04}}},
+		}
+
+		for enqueueIndex, write := range enqueues {
+			if err := path.enqueue(write); err != nil {
+				t.Fatalf(
+					"expected enqueue #%d success in iteration %d, got %v",
+					enqueueIndex,
+					iteration,
+					err,
+				)
+			}
+		}
+
+		sequence := make([]WriteEnvelope, 0, len(wantSequence))
+		for range wantSequence {
+			write, ok := path.NextWrite()
+			if !ok {
+				t.Fatalf("expected write availability in iteration %d", iteration)
+			}
+			sequence = append(sequence, write)
+		}
+
+		if !reflect.DeepEqual(sequence, wantSequence) {
+			t.Fatalf(
+				"expected deterministic sequence in iteration %d:\nexpected: %#v\nactual: %#v",
+				iteration,
+				wantSequence,
+				sequence,
+			)
+		}
+	}
+}
+
+func TestSharedArbitrationPathSessionManagerIntegrationOrdering(t *testing.T) {
+	manager := sessionmanager.NewManager(
+		sessionmanager.Options{
+			InboundCapacity:  4,
+			OutboundCapacity: 8,
+		},
+		sessionmanager.Hooks{},
+	)
+
+	sessionA, err := manager.Register(sessionmanager.Identity{
+		ClientID:   "arb-a",
+		Protocol:   "enh",
+		RemoteAddr: "127.0.0.1:60001",
+	})
+	if err != nil {
+		t.Fatalf("expected register sessionA success, got %v", err)
+	}
+
+	sessionB, err := manager.Register(sessionmanager.Identity{
+		ClientID:   "arb-b",
+		Protocol:   "enh",
+		RemoteAddr: "127.0.0.1:60002",
+	})
+	if err != nil {
+		t.Fatalf("expected register sessionB success, got %v", err)
+	}
+
+	path := NewSharedArbitrationPath(NewAdaptiveScheduler(Options{StarvationAfter: 5}))
+
+	if err := path.EnqueuePassThrough(
+		sessionA.ID,
+		downstream.Frame{Command: 0x31, Payload: []byte{0xA1}},
+	); err != nil {
+		t.Fatalf("expected pass-through enqueue success, got %v", err)
+	}
+	if err := path.EnqueueEmulated(
+		sessionA.ID,
+		downstream.Frame{Command: 0x32, Payload: []byte{0xA2}},
+	); err != nil {
+		t.Fatalf("expected emulated enqueue success, got %v", err)
+	}
+	if err := path.EnqueueEmulated(
+		sessionB.ID,
+		downstream.Frame{Command: 0x41, Payload: []byte{0xB1}},
+	); err != nil {
+		t.Fatalf("expected emulated enqueue success, got %v", err)
+	}
+	if err := path.EnqueuePassThrough(
+		sessionB.ID,
+		downstream.Frame{Command: 0x42, Payload: []byte{0xB2}},
+	); err != nil {
+		t.Fatalf("expected pass-through enqueue success, got %v", err)
+	}
+
+	wantOrder := []uint64{sessionA.ID, sessionB.ID, sessionA.ID, sessionB.ID}
+	for index, expectedSessionID := range wantOrder {
+		write, ok := path.NextWrite()
+		if !ok {
+			t.Fatalf("expected write availability at index %d", index)
+		}
+
+		if write.ArbitrationID != expectedSessionID {
+			t.Fatalf(
+				"expected arbitration id %d at index %d, got %d",
+				expectedSessionID,
+				index,
+				write.ArbitrationID,
+			)
+		}
+	}
+
+	if path.Pending(sessionA.ID) != 0 || path.Pending(sessionB.ID) != 0 {
+		t.Fatalf("expected no pending writes after drain (a=%d b=%d)", path.Pending(sessionA.ID), path.Pending(sessionB.ID))
+	}
+}


### PR DESCRIPTION
Fixes #20

## Summary
- add `writescheduler.SharedArbitrationPath` to enforce a single arbitration/scheduler path for both pass-through and emulated writes
- route both write modes through one scheduler-backed queue map keyed by arbitration id, preserving per-id FIFO and shared global arbitration
- add explicit deterministic ordering tests (mixed-mode integration ordering, deterministic control-sequence loop, and session-manager integration touchpoint)
- document shared arbitration capability in architecture/readme package maps

## Validation
- `gofmt -w $(rg --files -g '*.go')`
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/terminology-gate.sh`

## Smoke verification notes
- deterministic ordering smoke: `GOWORK=off go test ./internal/scheduler/write -run 'TestSharedArbitrationPathIntegrationOrderingGuaranteeMixedModes|TestSharedArbitrationPathIntegrationDeterministicControlSequence|TestSharedArbitrationPathSessionManagerIntegrationOrdering' -count=1 -v`
- observed markers: all shared-path integration ordering tests pass (single path arbitration, deterministic sequence stability, queue drain invariants)
