### PR TITLE
Implement adapter-proxy daemon entrypoint

### DIFF
--- a/cmd/helianthus-ebus-adapter-proxy/main.go
+++ b/cmd/helianthus-ebus-adapter-proxy/main.go
@@ -1,3 +1,91 @@
 package main
 
-func main() {}
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/adapterproxy"
+)
+
+func main() {
+	listenAddr := flag.String("listen", "0.0.0.0:19001", "listen address for downstream ebusd-compatible enhanced protocol clients")
+	upstream := flag.String("upstream", "", "upstream enhanced endpoint (e.g. enh://host:port or ens://host:port)")
+	dialTimeout := flag.Duration("dial-timeout", 3*time.Second, "upstream dial timeout")
+	readTimeout := flag.Duration("read-timeout", 200*time.Millisecond, "read timeout applied to upstream and downstream sockets")
+	writeTimeout := flag.Duration("write-timeout", 2*time.Second, "write timeout applied to upstream and downstream sockets")
+	flag.Parse()
+
+	normalizedListen, err := normalizeListenAddr(*listenAddr)
+	if err != nil {
+		log.Fatalf("invalid -listen: %v", err)
+	}
+
+	normalizedUpstream, err := normalizeUpstreamEndpoint(*upstream)
+	if err != nil {
+		log.Fatalf("invalid -upstream: %v", err)
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	log.Printf("Starting eBUS adapter proxy")
+	log.Printf("Listen: %s", normalizedListen)
+	log.Printf("Upstream: (configured)")
+
+	server := adapterproxy.NewServer(adapterproxy.Config{
+		ListenAddr:   normalizedListen,
+		UpstreamAddr: normalizedUpstream,
+		DialTimeout:  *dialTimeout,
+		ReadTimeout:  *readTimeout,
+		WriteTimeout: *writeTimeout,
+	})
+
+	if err := server.Serve(ctx); err != nil {
+		log.Fatalf("proxy exited: %v", err)
+	}
+}
+
+func normalizeListenAddr(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("listen address is required")
+	}
+	_, _, err := net.SplitHostPort(trimmed)
+	if err != nil {
+		return "", err
+	}
+	return trimmed, nil
+}
+
+func normalizeUpstreamEndpoint(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("upstream endpoint is required")
+	}
+
+	if strings.Contains(trimmed, "://") {
+		parsed, err := url.Parse(trimmed)
+		if err != nil {
+			return "", err
+		}
+		if parsed.Host == "" {
+			return "", fmt.Errorf("upstream endpoint missing host: %q", raw)
+		}
+		return parsed.Host, nil
+	}
+
+	_, _, err := net.SplitHostPort(trimmed)
+	if err != nil {
+		return "", err
+	}
+	return trimmed, nil
+}

--- a/internal/adapterproxy/config.go
+++ b/internal/adapterproxy/config.go
@@ -1,0 +1,11 @@
+package adapterproxy
+
+import "time"
+
+type Config struct {
+	ListenAddr   string
+	UpstreamAddr string
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+}

--- a/internal/adapterproxy/request_parser.go
+++ b/internal/adapterproxy/request_parser.go
@@ -1,0 +1,87 @@
+package adapterproxy
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+var errMalformedRequest = errors.New("enh malformed request")
+
+// requestParser parses enhanced protocol requests flowing from a downstream client.
+//
+// Unlike adapter responses, raw bytes < 0x80 represent short-form SEND requests.
+type requestParser struct {
+	pending bool
+	byte1   byte
+}
+
+func (parser *requestParser) Reset() {
+	parser.pending = false
+	parser.byte1 = 0
+}
+
+func (parser *requestParser) Parse(reader io.Reader) (downstream.Frame, error) {
+	buffer := make([]byte, 1)
+
+	for {
+		if _, err := io.ReadFull(reader, buffer); err != nil {
+			return downstream.Frame{}, err
+		}
+
+		frame, complete, err := parser.Feed(buffer[0])
+		if err != nil {
+			return downstream.Frame{}, err
+		}
+
+		if complete {
+			return frame, nil
+		}
+	}
+}
+
+func (parser *requestParser) Feed(payloadByte byte) (downstream.Frame, bool, error) {
+	if !parser.pending {
+		if payloadByte&0x80 == 0 {
+			return downstream.Frame{
+				Command: byte(southboundenh.ENHReqSend),
+				Payload: []byte{payloadByte},
+			}, true, nil
+		}
+
+		if payloadByte&0xC0 == 0x80 {
+			return downstream.Frame{}, false, fmt.Errorf(
+				"%w: orphan second byte 0x%02X",
+				errMalformedRequest,
+				payloadByte,
+			)
+		}
+
+		parser.pending = true
+		parser.byte1 = payloadByte
+		return downstream.Frame{}, false, nil
+	}
+
+	if payloadByte&0xC0 != 0x80 {
+		parser.pending = false
+		return downstream.Frame{}, false, fmt.Errorf(
+			"%w: invalid second byte 0x%02X",
+			errMalformedRequest,
+			payloadByte,
+		)
+	}
+
+	command, data, err := southboundenh.DecodeENH(parser.byte1, payloadByte)
+	parser.pending = false
+	if err != nil {
+		return downstream.Frame{}, false, err
+	}
+
+	return downstream.Frame{
+		Command: byte(command),
+		Payload: []byte{data},
+	}, true, nil
+}

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1,0 +1,453 @@
+package adapterproxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/sourcepolicy"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+const (
+	defaultLeaseDuration = 30 * time.Minute
+)
+
+type Server struct {
+	cfg Config
+
+	listener net.Listener
+	upstream *upstreamClient
+
+	mutex    sync.Mutex
+	sessions map[uint64]*session
+	nextID   uint64
+
+	busToken chan struct{}
+	busOwner uint64
+
+	pendingStartMu sync.Mutex
+	pendingStart   *pendingStart
+
+	leasesMu     sync.Mutex
+	leaseManager *sourcepolicy.LeaseManager
+	leasedBySess map[uint64]sourcepolicy.Lease
+
+	waitGroup sync.WaitGroup
+}
+
+type pendingStart struct {
+	sessionID uint64
+	respCh    chan downstream.Frame
+}
+
+func NewServer(cfg Config) *Server {
+	server := &Server{
+		cfg:          cfg,
+		sessions:     make(map[uint64]*session),
+		busToken:     make(chan struct{}, 1),
+		leasedBySess: make(map[uint64]sourcepolicy.Lease),
+	}
+	server.busToken <- struct{}{}
+
+	policy, err := sourcepolicy.NewPolicy(sourcepolicy.Config{
+		ReservationMode: sourcepolicy.ReservationModeSoft,
+	})
+	if err == nil {
+		manager, managerErr := sourcepolicy.NewLeaseManager(policy, sourcepolicy.LeaseManagerOptions{
+			LeaseDuration: defaultLeaseDuration,
+		})
+		if managerErr == nil {
+			server.leaseManager = manager
+		}
+	}
+
+	return server
+}
+
+func (server *Server) Serve(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	upstream, err := dialUpstream(ctx, server.cfg.UpstreamAddr, server.cfg.DialTimeout, server.cfg.ReadTimeout, server.cfg.WriteTimeout)
+	if err != nil {
+		return fmt.Errorf("dial upstream: %w", err)
+	}
+	server.upstream = upstream
+	if err := server.upstream.SendInit(0x00); err != nil {
+		// Best-effort: some adapters respond with RESETTED, others start streaming immediately.
+	}
+
+	listener, err := net.Listen("tcp", server.cfg.ListenAddr)
+	if err != nil {
+		_ = upstream.Close()
+		return fmt.Errorf("listen %q: %w", server.cfg.ListenAddr, err)
+	}
+	server.listener = listener
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	for {
+		connection, err := listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				break
+			}
+			if isClosedNetworkError(err) {
+				break
+			}
+			continue
+		}
+
+		sessionState := server.registerSession(connection)
+		server.waitGroup.Add(2)
+		go func() {
+			defer server.waitGroup.Done()
+			sessionState.runWriter(nil)
+		}()
+		go func() {
+			defer server.waitGroup.Done()
+			sessionState.runReader(
+				func(frame downstream.Frame) {
+					server.handleFrame(ctx, sessionState.id, frame)
+				},
+				nil,
+			)
+			server.unregisterSession(sessionState.id)
+		}()
+	}
+
+	_ = listener.Close()
+	server.closeSessions()
+	server.waitGroup.Wait()
+	_ = upstream.Close()
+
+	return nil
+}
+
+func (server *Server) registerSession(connection net.Conn) *session {
+	server.mutex.Lock()
+	server.nextID++
+	id := server.nextID
+	sessionState := newSession(id, connection, server.cfg.ReadTimeout, server.cfg.WriteTimeout)
+	server.sessions[id] = sessionState
+	server.mutex.Unlock()
+	return sessionState
+}
+
+func (server *Server) unregisterSession(sessionID uint64) {
+	server.mutex.Lock()
+	delete(server.sessions, sessionID)
+	server.mutex.Unlock()
+
+	server.releaseBusIfOwner(sessionID)
+	server.releaseLease(sessionID)
+
+	server.pendingStartMu.Lock()
+	if server.pendingStart != nil && server.pendingStart.sessionID == sessionID {
+		server.pendingStart = nil
+	}
+	server.pendingStartMu.Unlock()
+}
+
+func (server *Server) closeSessions() {
+	server.mutex.Lock()
+	sessions := make([]*session, 0, len(server.sessions))
+	for _, sess := range server.sessions {
+		sessions = append(sessions, sess)
+	}
+	server.sessions = make(map[uint64]*session)
+	server.mutex.Unlock()
+
+	for _, sess := range sessions {
+		_ = sess.Close()
+	}
+}
+
+func (server *Server) handleFrame(ctx context.Context, sessionID uint64, frame downstream.Frame) {
+	command := southboundenh.ENHCommand(frame.Command)
+	if len(frame.Payload) != 1 {
+		return
+	}
+	data := frame.Payload[0]
+
+	switch command {
+	case southboundenh.ENHReqInit:
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResResetted),
+			Payload: []byte{data},
+		})
+	case southboundenh.ENHReqInfo:
+		// Respond with a zero-length info payload.
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResInfo),
+			Payload: []byte{0x00},
+		})
+	case southboundenh.ENHReqStart:
+		go server.handleStart(ctx, sessionID, data)
+	case southboundenh.ENHReqSend:
+		server.handleSend(sessionID, data)
+	default:
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResErrorHost),
+			Payload: []byte{0x00},
+		})
+	}
+}
+
+func (server *Server) handleStart(ctx context.Context, sessionID uint64, initiator byte) {
+	if !server.acquireLease(sessionID, initiator) {
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResErrorHost),
+			Payload: []byte{0x00},
+		})
+		return
+	}
+
+	select {
+	case <-server.busToken:
+	case <-ctx.Done():
+		return
+	}
+
+	respCh := make(chan downstream.Frame, 1)
+	server.pendingStartMu.Lock()
+	server.pendingStart = &pendingStart{
+		sessionID: sessionID,
+		respCh:    respCh,
+	}
+	server.pendingStartMu.Unlock()
+
+	startFrame := downstream.Frame{
+		Command: byte(southboundenh.ENHReqStart),
+		Payload: []byte{initiator},
+	}
+	if err := server.upstream.WriteFrame(startFrame); err != nil {
+		server.clearPendingStart(sessionID)
+		server.releaseBusToken()
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResErrorHost),
+			Payload: []byte{0x00},
+		})
+		return
+	}
+
+	select {
+	case response := <-respCh:
+		server.clearPendingStart(sessionID)
+		server.reply(sessionID, response)
+
+		switch southboundenh.ENHCommand(response.Command) {
+		case southboundenh.ENHResStarted:
+			server.mutex.Lock()
+			server.busOwner = sessionID
+			server.mutex.Unlock()
+			return
+		default:
+			server.releaseBusToken()
+			return
+		}
+	case <-time.After(5 * time.Second):
+		server.clearPendingStart(sessionID)
+		server.releaseBusToken()
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResErrorHost),
+			Payload: []byte{0x00},
+		})
+		return
+	case <-ctx.Done():
+		server.clearPendingStart(sessionID)
+		server.releaseBusToken()
+		return
+	}
+}
+
+func (server *Server) handleSend(sessionID uint64, data byte) {
+	server.mutex.Lock()
+	owner := server.busOwner
+	server.mutex.Unlock()
+
+	if owner != sessionID {
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResErrorHost),
+			Payload: []byte{0x00},
+		})
+		return
+	}
+
+	sendFrame := downstream.Frame{
+		Command: byte(southboundenh.ENHReqSend),
+		Payload: []byte{data},
+	}
+	if err := server.upstream.WriteFrame(sendFrame); err != nil {
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResErrorHost),
+			Payload: []byte{0x00},
+		})
+		server.releaseBusIfOwner(sessionID)
+		return
+	}
+
+	if data == 0xAA {
+		server.releaseBusIfOwner(sessionID)
+	}
+}
+
+func (server *Server) runUpstreamReader(ctx context.Context) {
+	defer server.waitGroup.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		frame, err := server.upstream.ReadFrame()
+		if err != nil {
+			if isTimeoutError(err) {
+				continue
+			}
+			if errors.Is(err, io.EOF) || isClosedNetworkError(err) {
+				return
+			}
+			continue
+		}
+
+		switch southboundenh.ENHCommand(frame.Command) {
+		case southboundenh.ENHResReceived, southboundenh.ENHResResetted:
+			server.broadcast(frame)
+		case southboundenh.ENHResStarted, southboundenh.ENHResFailed,
+			southboundenh.ENHResErrorEBUS, southboundenh.ENHResErrorHost:
+			if server.deliverPendingStart(frame) {
+				continue
+			}
+		default:
+		}
+	}
+}
+
+func (server *Server) deliverPendingStart(frame downstream.Frame) bool {
+	server.pendingStartMu.Lock()
+	pending := server.pendingStart
+	server.pendingStartMu.Unlock()
+	if pending == nil {
+		return false
+	}
+
+	select {
+	case pending.respCh <- cloneFrame(frame):
+	default:
+	}
+
+	return true
+}
+
+func (server *Server) clearPendingStart(sessionID uint64) {
+	server.pendingStartMu.Lock()
+	if server.pendingStart != nil && server.pendingStart.sessionID == sessionID {
+		server.pendingStart = nil
+	}
+	server.pendingStartMu.Unlock()
+}
+
+func (server *Server) broadcast(frame downstream.Frame) {
+	server.mutex.Lock()
+	sessions := make([]*session, 0, len(server.sessions))
+	for _, sess := range server.sessions {
+		sessions = append(sessions, sess)
+	}
+	server.mutex.Unlock()
+
+	for _, sess := range sessions {
+		sess.enqueue(frame)
+	}
+}
+
+func (server *Server) reply(sessionID uint64, frame downstream.Frame) {
+	server.mutex.Lock()
+	sess := server.sessions[sessionID]
+	server.mutex.Unlock()
+	if sess == nil {
+		return
+	}
+
+	sess.enqueue(frame)
+}
+
+func (server *Server) releaseBusIfOwner(sessionID uint64) {
+	server.mutex.Lock()
+	if server.busOwner != sessionID {
+		server.mutex.Unlock()
+		return
+	}
+	server.busOwner = 0
+	server.mutex.Unlock()
+
+	server.releaseBusToken()
+}
+
+func (server *Server) releaseBusToken() {
+	select {
+	case server.busToken <- struct{}{}:
+	default:
+	}
+}
+
+func (server *Server) acquireLease(sessionID uint64, initiator byte) bool {
+	if server.leaseManager == nil {
+		return true
+	}
+
+	server.leasesMu.Lock()
+	defer server.leasesMu.Unlock()
+
+	if existing, ok := server.leasedBySess[sessionID]; ok {
+		return existing.Address == initiator
+	}
+
+	lease, err := server.leaseManager.Acquire(
+		fmt.Sprintf("session/%d", sessionID),
+		sourcepolicy.AcquireOptions{
+			Candidates:        []uint8{initiator},
+			AllowSoftReserved: true,
+		},
+	)
+	if err != nil {
+		return false
+	}
+
+	server.leasedBySess[sessionID] = lease
+	return true
+}
+
+func (server *Server) releaseLease(sessionID uint64) {
+	if server.leaseManager == nil {
+		return
+	}
+
+	server.leasesMu.Lock()
+	lease, ok := server.leasedBySess[sessionID]
+	if ok {
+		delete(server.leasedBySess, sessionID)
+	}
+	server.leasesMu.Unlock()
+
+	if ok {
+		_, _ = server.leaseManager.Release(lease.OwnerID)
+	}
+}
+
+func isClosedNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, net.ErrClosed)
+}

--- a/internal/adapterproxy/session.go
+++ b/internal/adapterproxy/session.go
@@ -1,0 +1,136 @@
+package adapterproxy
+
+import (
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+type session struct {
+	id         uint64
+	remoteAddr string
+
+	conn         net.Conn
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
+	parser  requestParser
+	encoder southboundenh.ENHEncoder
+
+	sendCh chan downstream.Frame
+
+	closeOnce sync.Once
+	done      chan struct{}
+}
+
+func newSession(
+	id uint64,
+	conn net.Conn,
+	readTimeout time.Duration,
+	writeTimeout time.Duration,
+) *session {
+	return &session{
+		id:           id,
+		remoteAddr:   conn.RemoteAddr().String(),
+		conn:         conn,
+		readTimeout:  readTimeout,
+		writeTimeout: writeTimeout,
+		sendCh:       make(chan downstream.Frame, 512),
+		done:         make(chan struct{}),
+	}
+}
+
+func (s *session) Close() error {
+	var closeErr error
+	s.closeOnce.Do(func() {
+		close(s.done)
+		closeErr = s.conn.Close()
+	})
+	return closeErr
+}
+
+func (s *session) enqueue(frame downstream.Frame) bool {
+	select {
+	case s.sendCh <- cloneFrame(frame):
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *session) runWriter(onError func(error)) {
+	for {
+		select {
+		case <-s.done:
+			return
+		case frame := <-s.sendCh:
+			payload, err := s.encoder.Encode(frame)
+			if err != nil {
+				if onError != nil {
+					onError(err)
+				}
+				continue
+			}
+
+			_ = setWriteDeadline(s.conn, s.writeTimeout)
+			if err := writeAll(s.conn, payload); err != nil {
+				if onError != nil {
+					onError(err)
+				}
+				_ = s.Close()
+				return
+			}
+		}
+	}
+}
+
+func (s *session) runReader(onFrame func(downstream.Frame), onError func(error)) {
+	for {
+		select {
+		case <-s.done:
+			return
+		default:
+		}
+
+		_ = setReadDeadline(s.conn, s.readTimeout)
+		frame, err := s.parser.Parse(s.conn)
+		if err != nil {
+			if isTimeoutError(err) {
+				continue
+			}
+			if err == io.EOF {
+				_ = s.Close()
+				return
+			}
+			if onError != nil {
+				onError(err)
+			}
+			_ = s.Close()
+			return
+		}
+
+		if onFrame != nil {
+			onFrame(frame)
+		}
+	}
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	netErr, ok := err.(net.Error)
+	return ok && netErr.Timeout()
+}
+
+func cloneFrame(frame downstream.Frame) downstream.Frame {
+	return downstream.Frame{
+		Address: frame.Address,
+		Command: frame.Command,
+		Payload: append([]byte(nil), frame.Payload...),
+	}
+}

--- a/internal/adapterproxy/upstream.go
+++ b/internal/adapterproxy/upstream.go
@@ -1,0 +1,127 @@
+package adapterproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+type upstreamClient struct {
+	conn         net.Conn
+	readTimeout  time.Duration
+	writeTimeout time.Duration
+
+	parser  southboundenh.ENHParser
+	encoder southboundenh.ENHEncoder
+
+	writeMu sync.Mutex
+}
+
+func dialUpstream(
+	ctx context.Context,
+	address string,
+	timeout time.Duration,
+	readTimeout time.Duration,
+	writeTimeout time.Duration,
+) (*upstreamClient, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	dialer := net.Dialer{Timeout: timeout}
+	conn, err := dialer.DialContext(ctx, "tcp", address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &upstreamClient{
+		conn:         conn,
+		readTimeout:  readTimeout,
+		writeTimeout: writeTimeout,
+	}, nil
+}
+
+func (client *upstreamClient) Close() error {
+	if client == nil || client.conn == nil {
+		return nil
+	}
+	return client.conn.Close()
+}
+
+func (client *upstreamClient) ReadFrame() (downstream.Frame, error) {
+	if client == nil || client.conn == nil {
+		return downstream.Frame{}, io.EOF
+	}
+
+	if err := setReadDeadline(client.conn, client.readTimeout); err != nil {
+		return downstream.Frame{}, err
+	}
+
+	return client.parser.Parse(client.conn)
+}
+
+func (client *upstreamClient) WriteFrame(frame downstream.Frame) error {
+	if client == nil || client.conn == nil {
+		return io.EOF
+	}
+
+	payload, err := client.encoder.Encode(frame)
+	if err != nil {
+		return err
+	}
+
+	client.writeMu.Lock()
+	defer client.writeMu.Unlock()
+
+	if err := setWriteDeadline(client.conn, client.writeTimeout); err != nil {
+		return err
+	}
+
+	if err := writeAll(client.conn, payload); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (client *upstreamClient) SendInit(features byte) error {
+	return client.WriteFrame(downstream.Frame{
+		Command: byte(southboundenh.ENHReqInit),
+		Payload: []byte{features},
+	})
+}
+
+func setReadDeadline(connection net.Conn, timeout time.Duration) error {
+	if timeout <= 0 {
+		return connection.SetReadDeadline(time.Time{})
+	}
+	return connection.SetReadDeadline(time.Now().Add(timeout))
+}
+
+func setWriteDeadline(connection net.Conn, timeout time.Duration) error {
+	if timeout <= 0 {
+		return connection.SetWriteDeadline(time.Time{})
+	}
+	return connection.SetWriteDeadline(time.Now().Add(timeout))
+}
+
+func writeAll(writer io.Writer, payload []byte) error {
+	remaining := payload
+	for len(remaining) > 0 {
+		written, err := writer.Write(remaining)
+		if err != nil {
+			return err
+		}
+		if written <= 0 {
+			return fmt.Errorf("short write")
+		}
+		remaining = remaining[written:]
+	}
+	return nil
+}


### PR DESCRIPTION
Closes #53.

## Summary
- Replaces stub `cmd/helianthus-ebus-adapter-proxy` with a real daemon that listens on `-listen` and proxies enhanced-protocol traffic to a single upstream enhanced endpoint.
- Supports multiple downstream clients with serialized START/SEND ownership, releases ownership on SYN (0xAA), and broadcasts RECEIVED bytes.
- Avoids logging the upstream endpoint value.

## Testing
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/terminology-gate.sh`

@chatgpt-codex-connector