### PR TITLE
Fix ENH proxy forwarding backpressure (arbitration lost)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         run: ./scripts/terminology-gate.sh
 
       - name: Runbook docs gate
-        run: ./scripts/verify_issue21_runbook.sh
+        run: ./scripts/runbook-gate.sh

--- a/internal/adapterproxy/encoding.go
+++ b/internal/adapterproxy/encoding.go
@@ -1,0 +1,38 @@
+package adapterproxy
+
+import (
+	"fmt"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+func encodeDownstreamFrame(encoder southboundenh.ENHEncoder, frame downstream.Frame) ([]byte, error) {
+	if len(frame.Payload) != 1 {
+		return nil, fmt.Errorf(
+			"enh frame payload must contain exactly one data byte, got %d",
+			len(frame.Payload),
+		)
+	}
+
+	if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResReceived && frame.Payload[0] < 0x80 {
+		return []byte{frame.Payload[0]}, nil
+	}
+
+	return encoder.Encode(frame)
+}
+
+func encodeUpstreamFrame(encoder southboundenh.ENHEncoder, frame downstream.Frame) ([]byte, error) {
+	if len(frame.Payload) != 1 {
+		return nil, fmt.Errorf(
+			"enh frame payload must contain exactly one data byte, got %d",
+			len(frame.Payload),
+		)
+	}
+
+	if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHReqSend && frame.Payload[0] < 0x80 {
+		return []byte{frame.Payload[0]}, nil
+	}
+
+	return encoder.Encode(frame)
+}

--- a/internal/adapterproxy/encoding_test.go
+++ b/internal/adapterproxy/encoding_test.go
@@ -1,0 +1,93 @@
+package adapterproxy
+
+import (
+	"testing"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+func TestEncodeDownstreamFrame_UsesShortFormForReceivedBelow80(t *testing.T) {
+	encoder := southboundenh.ENHEncoder{}
+	frame := downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x7F},
+	}
+
+	encoded, err := encodeDownstreamFrame(encoder, frame)
+	if err != nil {
+		t.Fatalf("encodeDownstreamFrame returned error: %v", err)
+	}
+
+	if len(encoded) != 1 || encoded[0] != 0x7F {
+		t.Fatalf("expected short form [0x7F], got %v", encoded)
+	}
+}
+
+func TestEncodeDownstreamFrame_EncodesReceivedAtOrAbove80(t *testing.T) {
+	encoder := southboundenh.ENHEncoder{}
+	frame := downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x80},
+	}
+
+	encoded, err := encodeDownstreamFrame(encoder, frame)
+	if err != nil {
+		t.Fatalf("encodeDownstreamFrame returned error: %v", err)
+	}
+
+	if len(encoded) != 2 {
+		t.Fatalf("expected 2-byte ENH encoding, got %v", encoded)
+	}
+}
+
+func TestEncodeDownstreamFrame_DoesNotShortFormNonReceived(t *testing.T) {
+	encoder := southboundenh.ENHEncoder{}
+	frame := downstream.Frame{
+		Command: byte(southboundenh.ENHResResetted),
+		Payload: []byte{0x00},
+	}
+
+	encoded, err := encodeDownstreamFrame(encoder, frame)
+	if err != nil {
+		t.Fatalf("encodeDownstreamFrame returned error: %v", err)
+	}
+
+	if len(encoded) != 2 {
+		t.Fatalf("expected 2-byte ENH encoding, got %v", encoded)
+	}
+}
+
+func TestEncodeUpstreamFrame_UsesShortFormForSendBelow80(t *testing.T) {
+	encoder := southboundenh.ENHEncoder{}
+	frame := downstream.Frame{
+		Command: byte(southboundenh.ENHReqSend),
+		Payload: []byte{0x01},
+	}
+
+	encoded, err := encodeUpstreamFrame(encoder, frame)
+	if err != nil {
+		t.Fatalf("encodeUpstreamFrame returned error: %v", err)
+	}
+
+	if len(encoded) != 1 || encoded[0] != 0x01 {
+		t.Fatalf("expected short form [0x01], got %v", encoded)
+	}
+}
+
+func TestEncodeUpstreamFrame_EncodesSendAtOrAbove80(t *testing.T) {
+	encoder := southboundenh.ENHEncoder{}
+	frame := downstream.Frame{
+		Command: byte(southboundenh.ENHReqSend),
+		Payload: []byte{0x80},
+	}
+
+	encoded, err := encodeUpstreamFrame(encoder, frame)
+	if err != nil {
+		t.Fatalf("encodeUpstreamFrame returned error: %v", err)
+	}
+
+	if len(encoded) != 2 {
+		t.Fatalf("expected 2-byte ENH encoding, got %v", encoded)
+	}
+}

--- a/internal/adapterproxy/session.go
+++ b/internal/adapterproxy/session.go
@@ -27,6 +27,11 @@ type session struct {
 	done      chan struct{}
 }
 
+const (
+	defaultSessionSendBuffer = 8192
+	defaultWriterBatchBytes  = 4096
+)
+
 func newSession(
 	id uint64,
 	conn net.Conn,
@@ -39,7 +44,7 @@ func newSession(
 		conn:         conn,
 		readTimeout:  readTimeout,
 		writeTimeout: writeTimeout,
-		sendCh:       make(chan downstream.Frame, 512),
+		sendCh:       make(chan downstream.Frame, defaultSessionSendBuffer),
 		done:         make(chan struct{}),
 	}
 }
@@ -63,29 +68,77 @@ func (s *session) enqueue(frame downstream.Frame) bool {
 }
 
 func (s *session) runWriter(onError func(error)) {
+	buffer := make([]byte, 0, defaultWriterBatchBytes)
+
 	for {
 		select {
 		case <-s.done:
 			return
 		case frame := <-s.sendCh:
-			payload, err := s.encoder.Encode(frame)
-			if err != nil {
-				if onError != nil {
-					onError(err)
-				}
-				continue
-			}
+			buffer = buffer[:0]
 
-			_ = setWriteDeadline(s.conn, s.writeTimeout)
-			if err := writeAll(s.conn, payload); err != nil {
-				if onError != nil {
-					onError(err)
+			for {
+				payload, err := encodeDownstreamFrame(s.encoder, frame)
+				if err != nil {
+					if onError != nil {
+						onError(err)
+					}
+				} else {
+					if len(payload) > cap(buffer) {
+						if err := flushWriterBuffer(s, buffer, onError); err != nil {
+							return
+						}
+						buffer = buffer[:0]
+						_ = setWriteDeadline(s.conn, s.writeTimeout)
+						if err := writeAll(s.conn, payload); err != nil {
+							if onError != nil {
+								onError(err)
+							}
+							_ = s.Close()
+							return
+						}
+					} else if len(buffer)+len(payload) > cap(buffer) && len(buffer) > 0 {
+						if err := flushWriterBuffer(s, buffer, onError); err != nil {
+							return
+						}
+						buffer = buffer[:0]
+					}
+					buffer = append(buffer, payload...)
 				}
-				_ = s.Close()
-				return
+
+				select {
+				case <-s.done:
+					return
+				case frame = <-s.sendCh:
+					continue
+				default:
+					if err := flushWriterBuffer(s, buffer, onError); err != nil {
+						return
+					}
+					break
+				}
+
+				break
 			}
 		}
 	}
+}
+
+func flushWriterBuffer(s *session, buffer []byte, onError func(error)) error {
+	if len(buffer) == 0 {
+		return nil
+	}
+
+	_ = setWriteDeadline(s.conn, s.writeTimeout)
+	if err := writeAll(s.conn, buffer); err != nil {
+		if onError != nil {
+			onError(err)
+		}
+		_ = s.Close()
+		return err
+	}
+
+	return nil
 }
 
 func (s *session) runReader(onFrame func(downstream.Frame), onError func(error)) {

--- a/internal/adapterproxy/upstream.go
+++ b/internal/adapterproxy/upstream.go
@@ -71,7 +71,7 @@ func (client *upstreamClient) WriteFrame(frame downstream.Frame) error {
 		return io.EOF
 	}
 
-	payload, err := client.encoder.Encode(frame)
+	payload, err := encodeUpstreamFrame(client.encoder, frame)
 	if err != nil {
 		return err
 	}

--- a/scripts/runbook-gate.sh
+++ b/scripts/runbook-gate.sh
@@ -45,4 +45,5 @@ for pattern in "${required_patterns[@]}"; do
 	fi
 done
 
-echo "PASS: issue #21 runbook markers verified"
+echo "PASS: operations runbook markers verified"
+


### PR DESCRIPTION
Refs: #55

## Summary
- Reduce ENH stream overhead by emitting short-form bytes where the protocol allows it (SEND/RECEIVED < 0x80).
- Batch downstream writes to avoid per-byte syscall overhead and reduce queue overruns/drops.
- Rename the runbook gate script so we don't carry `verify_issue*` artifacts in-repo; CI updated accordingly.

## Local validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `./scripts/terminology-gate.sh`
- `./scripts/runbook-gate.sh`

## Next
- Deploy new proxy build to HA add-on and re-run ebusd initial scan + vrc-explorer scan through the proxy.