### PR TITLE
adapter-proxy: flush downstream frames immediately

### DIFF
--- a/internal/adapterproxy/session.go
+++ b/internal/adapterproxy/session.go
@@ -29,7 +29,6 @@ type session struct {
 
 const (
 	defaultSessionSendBuffer = 8192
-	defaultWriterBatchBytes  = 4096
 )
 
 func newSession(
@@ -38,6 +37,8 @@ func newSession(
 	readTimeout time.Duration,
 	writeTimeout time.Duration,
 ) *session {
+	enableLowLatencySocketOptions(conn)
+
 	return &session{
 		id:           id,
 		remoteAddr:   conn.RemoteAddr().String(),
@@ -68,77 +69,29 @@ func (s *session) enqueue(frame downstream.Frame) bool {
 }
 
 func (s *session) runWriter(onError func(error)) {
-	buffer := make([]byte, 0, defaultWriterBatchBytes)
-
 	for {
 		select {
 		case <-s.done:
 			return
 		case frame := <-s.sendCh:
-			buffer = buffer[:0]
-
-			for {
-				payload, err := encodeDownstreamFrame(s.encoder, frame)
-				if err != nil {
-					if onError != nil {
-						onError(err)
-					}
-				} else {
-					if len(payload) > cap(buffer) {
-						if err := flushWriterBuffer(s, buffer, onError); err != nil {
-							return
-						}
-						buffer = buffer[:0]
-						_ = setWriteDeadline(s.conn, s.writeTimeout)
-						if err := writeAll(s.conn, payload); err != nil {
-							if onError != nil {
-								onError(err)
-							}
-							_ = s.Close()
-							return
-						}
-					} else if len(buffer)+len(payload) > cap(buffer) && len(buffer) > 0 {
-						if err := flushWriterBuffer(s, buffer, onError); err != nil {
-							return
-						}
-						buffer = buffer[:0]
-					}
-					buffer = append(buffer, payload...)
+			payload, err := encodeDownstreamFrame(s.encoder, frame)
+			if err != nil {
+				if onError != nil {
+					onError(err)
 				}
+				continue
+			}
 
-				select {
-				case <-s.done:
-					return
-				case frame = <-s.sendCh:
-					continue
-				default:
-					if err := flushWriterBuffer(s, buffer, onError); err != nil {
-						return
-					}
-					break
+			_ = setWriteDeadline(s.conn, s.writeTimeout)
+			if err := writeAll(s.conn, payload); err != nil {
+				if onError != nil {
+					onError(err)
 				}
-
-				break
+				_ = s.Close()
+				return
 			}
 		}
 	}
-}
-
-func flushWriterBuffer(s *session, buffer []byte, onError func(error)) error {
-	if len(buffer) == 0 {
-		return nil
-	}
-
-	_ = setWriteDeadline(s.conn, s.writeTimeout)
-	if err := writeAll(s.conn, buffer); err != nil {
-		if onError != nil {
-			onError(err)
-		}
-		_ = s.Close()
-		return err
-	}
-
-	return nil
 }
 
 func (s *session) runReader(onFrame func(downstream.Frame), onError func(error)) {
@@ -186,4 +139,15 @@ func cloneFrame(frame downstream.Frame) downstream.Frame {
 		Command: frame.Command,
 		Payload: append([]byte(nil), frame.Payload...),
 	}
+}
+
+func enableLowLatencySocketOptions(connection net.Conn) {
+	tcpConn, ok := connection.(*net.TCPConn)
+	if !ok {
+		return
+	}
+
+	_ = tcpConn.SetNoDelay(true)
+	_ = tcpConn.SetKeepAlive(true)
+	_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
 }

--- a/internal/adapterproxy/upstream.go
+++ b/internal/adapterproxy/upstream.go
@@ -40,6 +40,12 @@ func dialUpstream(
 		return nil, err
 	}
 
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		_ = tcpConn.SetNoDelay(true)
+		_ = tcpConn.SetKeepAlive(true)
+		_ = tcpConn.SetKeepAlivePeriod(30 * time.Second)
+	}
+
 	return &upstreamClient{
 		conn:         conn,
 		readTimeout:  readTimeout,


### PR DESCRIPTION
Problem: downstream writer batched ENH frames into multi-KB bursts (up to 4096 bytes) before flushing. This can delay received bus symbols and make ebusd operate on stale bus state, showing up as repeated 'ERR: arbitration lost' during initial broadcast scan when routed through the proxy.

Fix:
- Write each downstream frame immediately (no batching).
- Enable low-latency socket options (TCP_NODELAY + keepalive) on downstream sessions and upstream connection.

Validation:
- gofmt (git ls-files '*.go')
- GOWORK=off go test ./...
- GOWORK=off go vet ./...
- ./scripts/terminology-gate.sh