### PR TITLE
adapter-proxy: release bus on upstream errors

### DIFF
--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -421,6 +421,9 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 			if server.deliverPendingStart(frame) {
 				continue
 			}
+			if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResFailed {
+				server.deliverUpstreamFailed(frame)
+			}
 		default:
 		}
 	}
@@ -560,6 +563,21 @@ func (server *Server) deliverUpstreamError(frame downstream.Frame) {
 
 	if owner != 0 {
 		server.reply(owner, frame)
+		server.releaseBusIfOwner(owner)
+		return
+	}
+
+	server.broadcast(frame)
+}
+
+func (server *Server) deliverUpstreamFailed(frame downstream.Frame) {
+	server.mutex.Lock()
+	owner := server.busOwner
+	server.mutex.Unlock()
+
+	if owner != 0 {
+		server.reply(owner, frame)
+		server.releaseBusIfOwner(owner)
 		return
 	}
 


### PR DESCRIPTION
When upstream reports ERROR_* or FAILED while a session owns the bus, the proxy must release its internal bus token/ownership so the client can retry cleanly.

This change:
- Delivers upstream FAILED (when not part of a pending START) to the current bus owner.
- Releases the proxy bus ownership/token on upstream FAILED and on upstream ERROR_* delivered to the owner.

Intended effect: prevent bus lockup / retry loops that manifest as read timeouts, framing errors, and persistent arbitration failures when ebusd is behind the proxy.
