### PR TITLE
meta01: add local CI entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,5 +5,7 @@ These instructions apply to the entire repository.
 1. Keep changes targeted to the requested issue.
 2. Prefer small, composable packages under `internal/`.
 3. Always run `gofmt ./...` before finishing.
-4. Validate with `go test ./...`, `go vet ./...`, and `./scripts/terminology-gate.sh`.
-5. Keep repository terminology inclusive and consistent.
+4. Validate with `./scripts/ci_local.sh` (local CI is authoritative if GitHub Actions minutes are unavailable).
+5. React (emoji) to every review comment and reply with status when actioned.
+6. Keep repository terminology inclusive and consistent.
+7. If a change modifies externally visible behavior, update `helianthus-docs-ebus` alongside the code change (doc-gate).

--- a/README.md
+++ b/README.md
@@ -40,10 +40,7 @@ adapter endpoint/ebusd -> helianthus-ebus-adapter-proxy -> helianthus-ebusgatewa
 ```bash
 git clone https://github.com/d3vi1/helianthus-ebus-adapter-proxy.git
 cd helianthus-ebus-adapter-proxy
-GOWORK=off go test ./...
-GOWORK=off go vet ./...
-./scripts/terminology-gate.sh
-./scripts/verify_issue21_runbook.sh
+./scripts/ci_local.sh
 ```
 
 ### 2) Local compatibility harness (simulated, no external hardware)

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> gofmt"
+unformatted="$(git ls-files '*.go' | xargs -n 50 gofmt -l || true)"
+if [ -n "${unformatted}" ]; then
+  echo "gofmt required for:"
+  echo "${unformatted}"
+  exit 1
+fi
+
+echo "==> go test"
+GOWORK=off go test ./...
+
+echo "==> go vet"
+GOWORK=off go vet ./...
+
+echo "==> terminology gate"
+./scripts/terminology-gate.sh
+
+echo "==> runbook docs gate"
+./scripts/runbook-gate.sh
+


### PR DESCRIPTION
Fixes #61.

Adds `scripts/ci_local.sh` as a single local CI entrypoint (gofmt check, go test/vet, terminology gate, runbook gate) and updates agent instructions + quickstart.