### PR TITLE
adapterproxy: release ownership on idle/terminal paths (#55)

### DIFF
--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -520,6 +520,11 @@ func (server *Server) handleStart(ctx context.Context, sessionID uint64, initiat
 					server.markSessionCollision(sessionID, 0x00)
 				}
 			}
+			if southboundenh.ENHCommand(response.Command) == southboundenh.ENHResFailed ||
+				southboundenh.ENHCommand(response.Command) == southboundenh.ENHResErrorEBUS ||
+				southboundenh.ENHCommand(response.Command) == southboundenh.ENHResErrorHost {
+				server.releaseBusIfOwner(sessionID)
+			}
 			if !ownedBySession {
 				server.releaseBusToken()
 			}
@@ -527,6 +532,7 @@ func (server *Server) handleStart(ctx context.Context, sessionID uint64, initiat
 		}
 	case <-time.After(5 * time.Second):
 		server.clearPendingStart(sessionID)
+		server.releaseBusIfOwner(sessionID)
 		if !ownedBySession {
 			server.releaseBusToken()
 		}
@@ -537,6 +543,7 @@ func (server *Server) handleStart(ctx context.Context, sessionID uint64, initiat
 		return
 	case <-ctx.Done():
 		server.clearPendingStart(sessionID)
+		server.releaseBusIfOwner(sessionID)
 		if !ownedBySession {
 			server.releaseBusToken()
 		}
@@ -1278,10 +1285,9 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 func (server *Server) releaseBusIfIdleSyn() {
 	server.mutex.Lock()
 	owner := server.busOwner
-	dirty := server.busDirty
 	server.mutex.Unlock()
 
-	if owner == 0 || !dirty {
+	if owner == 0 {
 		return
 	}
 

--- a/internal/adapterproxy/server_owner_release_test.go
+++ b/internal/adapterproxy/server_owner_release_test.go
@@ -1,0 +1,146 @@
+package adapterproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+func TestReleaseBusIfIdleSynReleasesCleanOwner(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(Config{})
+	server.busOwner = 7
+	server.busDirty = false
+
+	select {
+	case <-server.busToken:
+	default:
+		t.Fatalf("expected initial bus token")
+	}
+
+	server.releaseBusIfIdleSyn()
+
+	server.mutex.Lock()
+	owner := server.busOwner
+	dirty := server.busDirty
+	server.mutex.Unlock()
+	if owner != 0 {
+		t.Fatalf("busOwner = %d; want 0", owner)
+	}
+	if dirty {
+		t.Fatalf("busDirty = true; want false")
+	}
+
+	select {
+	case <-server.busToken:
+	default:
+		t.Fatalf("expected released bus token")
+	}
+}
+
+func TestHandleStartReleasesOwnerOnTerminalUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		command southboundenh.ENHCommand
+	}{
+		{name: "error_ebus", command: southboundenh.ENHResErrorEBUS},
+		{name: "error_host", command: southboundenh.ENHResErrorHost},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			upstream := newFakeUpstream()
+			server := NewServer(Config{UpstreamTransport: UpstreamENH})
+			server.upstream = upstream
+			server.sessions = map[uint64]*session{
+				1: {id: 1, sendCh: make(chan downstream.Frame, 8), done: make(chan struct{})},
+			}
+			server.busOwner = 1
+			server.busDirty = true
+
+			select {
+			case <-server.busToken:
+			default:
+				t.Fatalf("expected initial bus token")
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			server.waitGroup.Add(1)
+			go server.runUpstreamReader(ctx)
+
+			startDone := make(chan struct{})
+			go func() {
+				server.handleStart(ctx, 1, 0x31)
+				close(startDone)
+			}()
+
+			if !waitUntil(500*time.Millisecond, server.isStartPending) {
+				t.Fatalf("pending start was not registered")
+			}
+
+			upstream.readCh <- downstream.Frame{
+				Command: byte(testCase.command),
+				Payload: []byte{0x00},
+			}
+
+			select {
+			case <-startDone:
+			case <-time.After(750 * time.Millisecond):
+				t.Fatalf("handleStart did not return")
+			}
+
+			server.mutex.Lock()
+			owner := server.busOwner
+			dirty := server.busDirty
+			server.mutex.Unlock()
+			if owner != 0 {
+				t.Fatalf("busOwner = %d; want 0", owner)
+			}
+			if dirty {
+				t.Fatalf("busDirty = true; want false")
+			}
+
+			select {
+			case <-server.busToken:
+			default:
+				t.Fatalf("expected released bus token")
+			}
+
+			select {
+			case frame := <-server.sessions[1].sendCh:
+				if southboundenh.ENHCommand(frame.Command) != testCase.command {
+					t.Fatalf(
+						"session reply command = 0x%02X; want 0x%02X",
+						frame.Command,
+						byte(testCase.command),
+					)
+				}
+			case <-time.After(300 * time.Millisecond):
+				t.Fatalf("expected terminal error reply for session")
+			}
+
+			cancel()
+			_ = upstream.Close()
+			server.waitGroup.Wait()
+		})
+	}
+}
+
+func waitUntil(timeout time.Duration, condition func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return condition()
+}


### PR DESCRIPTION
## Summary
- release held ownership when upstream emits idle SYN even for clean owners
- release ownership when START receives terminal upstream errors (`ERROR_EBUS`/`ERROR_HOST`)
- add regression tests for both release paths

## Validation
- ./scripts/ci_local.sh

Closes #55
