### PR TITLE
Fix UDP plain START deadlock when upstream stream is cold

### DIFF
--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -25,6 +25,7 @@ const (
 	ebusSyn               = byte(0xAA)
 	busIdleReleaseGrace   = 400 * time.Millisecond
 	udpPlainSynWait       = 5 * time.Second
+	udpPlainBootstrapWait = 250 * time.Millisecond
 	udpPlainStartWait     = 5 * time.Second
 	udpPlainMaxAttempts   = 4
 	udpPlainBackoffBase   = 25 * time.Millisecond
@@ -53,6 +54,7 @@ type Server struct {
 	udpQueue     chan udpDatagram
 
 	upstreamFeatures atomic.Uint32
+	lastWireRXAtNano atomic.Int64
 
 	backpressureDrops  atomic.Uint64
 	backpressureCloses atomic.Uint64
@@ -633,22 +635,12 @@ func (server *Server) handleStartUDPPlain(ctx context.Context, sessionID uint64,
 	for attempt := 0; attempt < udpPlainMaxAttempts; attempt++ {
 		server.clearSynSignal()
 
-		synWait := time.Now()
-		select {
-		case <-server.synCh:
-		case <-time.After(udpPlainSynWait):
-			server.reply(sessionID, downstream.Frame{
-				Command: byte(southboundenh.ENHResErrorHost),
-				Payload: []byte{0x00},
-			})
-			return
-		case <-ctx.Done():
-			return
-		case <-sess.done:
+		waitedForSyn, ok := server.waitForUDPPlainIdleSyn(ctx, sess, sessionID, attempt+1)
+		if !ok {
 			return
 		}
-		if server.cfg.Debug {
-			log.Printf("session=%d attempt=%d syn_wait=%s", sessionID, attempt+1, time.Since(synWait))
+		if server.cfg.Debug && waitedForSyn {
+			log.Printf("session=%d attempt=%d udp_plain_syn_acquired=true", sessionID, attempt+1)
 		}
 
 		respCh := make(chan downstream.Frame, 1)
@@ -944,6 +936,7 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 				server.upstreamFeatures.Store(uint32(frame.Payload[0]))
 			}
 			if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResReceived && len(frame.Payload) == 1 {
+				server.lastWireRXAtNano.Store(time.Now().UTC().UnixNano())
 				if server.cfg.Debug {
 					log.Printf("wire_rx symbol=0x%02X", frame.Payload[0])
 				}
@@ -982,6 +975,62 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 		default:
 		}
 	}
+}
+
+func (server *Server) waitForUDPPlainIdleSyn(
+	ctx context.Context,
+	sess *session,
+	sessionID uint64,
+	attempt int,
+) (bool, bool) {
+	waitTimeout := udpPlainSynWait
+	bootstrapMode := !server.hasRecentWireRX(udpPlainSynWait)
+	if bootstrapMode {
+		waitTimeout = udpPlainBootstrapWait
+	}
+
+	synWait := time.Now()
+	select {
+	case <-server.synCh:
+		if server.cfg.Debug {
+			log.Printf("session=%d attempt=%d syn_wait=%s", sessionID, attempt, time.Since(synWait))
+		}
+		return true, true
+	case <-time.After(waitTimeout):
+		if bootstrapMode {
+			if server.cfg.Debug {
+				log.Printf(
+					"session=%d attempt=%d syn_wait_bootstrap_timeout=%s proceeding_without_syn=true",
+					sessionID,
+					attempt,
+					waitTimeout,
+				)
+			}
+			return false, true
+		}
+		server.reply(sessionID, downstream.Frame{
+			Command: byte(southboundenh.ENHResErrorHost),
+			Payload: []byte{0x00},
+		})
+		return true, false
+	case <-ctx.Done():
+		return false, false
+	case <-sess.done:
+		return false, false
+	}
+}
+
+func (server *Server) hasRecentWireRX(window time.Duration) bool {
+	if window <= 0 {
+		return false
+	}
+
+	lastSeen := server.lastWireRXAtNano.Load()
+	if lastSeen <= 0 {
+		return false
+	}
+
+	return time.Since(time.Unix(0, lastSeen)) <= window
 }
 
 func (server *Server) deliverPendingStart(frame downstream.Frame) bool {

--- a/internal/adapterproxy/server_udp_plain_test.go
+++ b/internal/adapterproxy/server_udp_plain_test.go
@@ -312,3 +312,45 @@ func TestHandleSendReturnsArbitrationFailedWhenCollisionActive(t *testing.T) {
 		t.Fatalf("expected arbitration failed reply")
 	}
 }
+
+func TestHandleStartUDPPlainBootstrapsWithoutObservedSyn(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(Config{
+		UpstreamTransport:      UpstreamUDPPlain,
+		AutoJoinActivityWindow: time.Minute,
+	})
+	server.upstream = newFakeUpstream()
+
+	sessionState := &session{
+		id:     1,
+		sendCh: make(chan downstream.Frame, 2),
+		done:   make(chan struct{}),
+	}
+	server.sessions = map[uint64]*session{1: sessionState}
+
+	go func() {
+		deadline := time.Now().Add(1500 * time.Millisecond)
+		for time.Now().Before(deadline) {
+			if server.isStartPending() {
+				_ = server.deliverPendingStartFromArbByte(0x31)
+				return
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+
+	server.handleStartUDPPlain(context.Background(), 1, 0x31)
+
+	select {
+	case frame := <-sessionState.sendCh:
+		if southboundenh.ENHCommand(frame.Command) != southboundenh.ENHResStarted {
+			t.Fatalf("command = 0x%02X; want ENHResStarted", frame.Command)
+		}
+		if len(frame.Payload) != 1 || frame.Payload[0] != 0x31 {
+			t.Fatalf("payload = %x; want [31]", frame.Payload)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected start response for udp bootstrap flow")
+	}
+}


### PR DESCRIPTION
## Summary
- avoid hard-failing START on udp-plain when no recent upstream bytes were observed yet
- add bootstrap mode: if stream is cold, wait briefly for SYN then proceed with START to bootstrap traffic
- keep strict SYN wait behavior when upstream traffic is already active
- add regression test for bootstrap START without observed SYN

## Why
In matrix runs with `proxy_up=udp`, the proxy could block on a 5s SYN wait before sending the first START byte. On cold UDP streams this can deadlock startup and produce no observed bus traffic.

## Validation
- `./scripts/ci_local.sh`

Fixes #71