### PR TITLE
fix(proxy): reset parser state on timeout/error paths

### DIFF
--- a/internal/adapterproxy/request_parser_test.go
+++ b/internal/adapterproxy/request_parser_test.go
@@ -1,0 +1,75 @@
+package adapterproxy
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+	southboundenh "github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/southbound/enh"
+)
+
+func TestRequestParserResetsStateAfterTimeoutFragment(t *testing.T) {
+	parser := &requestParser{}
+	reader, writer := net.Pipe()
+	defer func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
+
+	sequence := southboundenh.EncodeENH(southboundenh.ENHReqSend, 0x41)
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, writeErrErr := writer.Write([]byte{sequence[0]})
+		writeErr <- writeErrErr
+	}()
+
+	if err := reader.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("expected read deadline success, got %v", err)
+	}
+
+	_, err := parser.Parse(reader)
+	if !isTimeout(err) {
+		t.Fatalf("expected timeout during fragmented parse, got %v", err)
+	}
+
+	if err := <-writeErr; err != nil {
+		t.Fatalf("expected first write success, got %v", err)
+	}
+
+	parser.Reset()
+
+	if err := reader.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("expected read deadline reset success, got %v", err)
+	}
+
+	go func() {
+		_, writeErrErr := writer.Write([]byte{0x42})
+		writeErr <- writeErrErr
+	}()
+
+	frame, err := parser.Parse(reader)
+	if err != nil {
+		t.Fatalf("expected parse success after reset, got %v", err)
+	}
+
+	if err := <-writeErr; err != nil {
+		t.Fatalf("expected second write success, got %v", err)
+	}
+
+	expected := downstream.Frame{
+		Command: byte(southboundenh.ENHReqSend),
+		Payload: []byte{0x42},
+	}
+	if !reflect.DeepEqual(frame, expected) {
+		t.Fatalf("expected frame %#v, got %#v", expected, frame)
+	}
+}
+
+func isTimeout(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}

--- a/internal/adapterproxy/session.go
+++ b/internal/adapterproxy/session.go
@@ -109,6 +109,7 @@ func (s *session) runReader(onFrame func(downstream.Frame), onError func(error))
 		frame, err := s.parser.Parse(s.reader)
 		if err != nil {
 			if isTimeoutError(err) {
+				s.parser.Reset()
 				continue
 			}
 			if err == io.EOF {

--- a/internal/adapterproxy/upstream.go
+++ b/internal/adapterproxy/upstream.go
@@ -72,7 +72,12 @@ func (client *upstreamClient) ReadFrame() (downstream.Frame, error) {
 		return downstream.Frame{}, err
 	}
 
-	return client.parser.Parse(client.reader)
+	frame, err := client.parser.Parse(client.reader)
+	if isTimeoutError(err) {
+		client.parser.Reset()
+	}
+
+	return frame, err
 }
 
 func (client *upstreamClient) WriteFrame(frame downstream.Frame) error {

--- a/internal/northbound/enh/listener.go
+++ b/internal/northbound/enh/listener.go
@@ -204,6 +204,7 @@ func (listener *Listener) serveSession(
 		if err != nil {
 			switch {
 			case isTimeoutError(err):
+				resetIfSupported(parser)
 				continue
 			case errors.Is(err, io.EOF) || listener.isClosedError(err):
 				disconnectCause = err
@@ -332,4 +333,11 @@ func isTimeoutError(err error) bool {
 	}
 
 	return false
+}
+
+func resetIfSupported(parser any) {
+	resetter, ok := parser.(interface{ Reset() })
+	if ok {
+		resetter.Reset()
+	}
 }

--- a/internal/northbound/ens/listener.go
+++ b/internal/northbound/ens/listener.go
@@ -204,6 +204,7 @@ func (listener *Listener) serveSession(
 		if err != nil {
 			switch {
 			case isTimeoutError(err):
+				resetIfSupported(parser)
 				continue
 			case errors.Is(err, io.EOF) || listener.isClosedError(err):
 				disconnectCause = err
@@ -332,4 +333,11 @@ func isTimeoutError(err error) bool {
 	}
 
 	return false
+}
+
+func resetIfSupported(parser any) {
+	resetter, ok := parser.(interface{ Reset() })
+	if ok {
+		resetter.Reset()
+	}
 }

--- a/internal/southbound/enh/codec_test.go
+++ b/internal/southbound/enh/codec_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
 )
@@ -101,5 +103,62 @@ func TestENHParserRecoversAfterMalformedSecondByte(t *testing.T) {
 	}
 	if !reflect.DeepEqual(frame, expectedFrame) {
 		t.Fatalf("expected recovered frame %#v, got %#v", expectedFrame, frame)
+	}
+}
+
+func TestENHParserResetsStateAfterTimeoutFragment(t *testing.T) {
+	parser := &ENHParser{}
+	reader, writer := net.Pipe()
+	defer func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
+
+	sequence := EncodeENH(ENHReqSend, 0x41)
+	writeErr := make(chan error, 1)
+	go func() {
+		_, writeErrErr := writer.Write([]byte{sequence[0]})
+		writeErr <- writeErrErr
+	}()
+
+	if err := reader.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("expected read deadline success, got %v", err)
+	}
+
+	_, err := parser.Parse(reader)
+	if !isTimeoutError(err) {
+		t.Fatalf("expected timeout during fragmented parse, got %v", err)
+	}
+
+	if err := <-writeErr; err != nil {
+		t.Fatalf("expected first write success, got %v", err)
+	}
+
+	parser.Reset()
+
+	if err := reader.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("expected read deadline reset success, got %v", err)
+	}
+
+	go func() {
+		_, writeErrErr := writer.Write([]byte{0x42})
+		writeErr <- writeErrErr
+	}()
+
+	frame, err := parser.Parse(reader)
+	if err != nil {
+		t.Fatalf("expected parse success after reset, got %v", err)
+	}
+
+	if err := <-writeErr; err != nil {
+		t.Fatalf("expected second write success, got %v", err)
+	}
+
+	expected := downstream.Frame{
+		Command: byte(ENHResReceived),
+		Payload: []byte{0x42},
+	}
+	if !reflect.DeepEqual(frame, expected) {
+		t.Fatalf("expected frame %#v, got %#v", expected, frame)
 	}
 }

--- a/internal/southbound/enh/driver.go
+++ b/internal/southbound/enh/driver.go
@@ -172,6 +172,7 @@ func (driver *Driver) readLocked() (downstream.Frame, error) {
 	frame, err := driver.parser.Parse(connection)
 	if err != nil {
 		if isTimeoutError(err) {
+			resetIfSupported(driver.parser)
 			return downstream.Frame{}, wrapError(ErrReadTimeout, err)
 		}
 
@@ -347,5 +348,12 @@ func callHook(hook func()) {
 func callHookWithError(hook func(error), err error) {
 	if hook != nil {
 		hook(err)
+	}
+}
+
+func resetIfSupported(parser any) {
+	resetter, ok := parser.(interface{ Reset() })
+	if ok {
+		resetter.Reset()
 	}
 }

--- a/internal/southbound/ens/codec_test.go
+++ b/internal/southbound/ens/codec_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/d3vi1/helianthus-ebus-adapter-proxy/internal/domain/downstream"
 )
@@ -153,5 +155,61 @@ func TestDecodeENSRejectsDanglingEscape(t *testing.T) {
 	_, err := DecodeENS([]byte{ENSByteEscape})
 	if !errors.Is(err, ErrMalformedFrame) {
 		t.Fatalf("expected malformed frame error, got %v", err)
+	}
+}
+
+func TestENSParserResetsStateAfterTimeoutFragment(t *testing.T) {
+	parser := &ENSParser{}
+	reader, writer := net.Pipe()
+	defer func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	}()
+
+	writeErr := make(chan error, 1)
+	go func() {
+		_, writeErrErr := writer.Write([]byte{ENSByteEscape})
+		writeErr <- writeErrErr
+	}()
+
+	if err := reader.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("expected read deadline success, got %v", err)
+	}
+
+	_, err := parser.Parse(reader)
+	if !isTimeoutError(err) {
+		t.Fatalf("expected timeout during fragmented parse, got %v", err)
+	}
+
+	if err := <-writeErr; err != nil {
+		t.Fatalf("expected first write success, got %v", err)
+	}
+
+	parser.Reset()
+
+	if err := reader.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("expected read deadline reset success, got %v", err)
+	}
+
+	go func() {
+		_, writeErrErr := writer.Write([]byte{0x41})
+		writeErr <- writeErrErr
+	}()
+
+	frame, err := parser.Parse(reader)
+	if err != nil {
+		t.Fatalf("expected parse success after reset, got %v", err)
+	}
+
+	if err := <-writeErr; err != nil {
+		t.Fatalf("expected second write success, got %v", err)
+	}
+
+	expected := downstream.Frame{
+		Command: byte(ENSCommandData),
+		Payload: []byte{0x41},
+	}
+	if !reflect.DeepEqual(frame, expected) {
+		t.Fatalf("expected frame %#v, got %#v", expected, frame)
 	}
 }

--- a/internal/southbound/ens/driver.go
+++ b/internal/southbound/ens/driver.go
@@ -172,6 +172,7 @@ func (driver *Driver) readLocked() (downstream.Frame, error) {
 	frame, err := driver.parser.Parse(connection)
 	if err != nil {
 		if isTimeoutError(err) {
+			resetIfSupported(driver.parser)
 			return downstream.Frame{}, wrapError(ErrReadTimeout, err)
 		}
 
@@ -347,5 +348,12 @@ func callHook(hook func()) {
 func callHookWithError(hook func(error), err error) {
 	if hook != nil {
 		hook(err)
+	}
+}
+
+func resetIfSupported(parser any) {
+	resetter, ok := parser.(interface{ Reset() })
+	if ok {
+		resetter.Reset()
 	}
 }


### PR DESCRIPTION
## Summary

- Reset parser state at all 6 timeout sites to prevent stale-state frame corruption
- Use `resetIfSupported()` type assertion pattern for interface-accessed parsers
- Direct `Reset()` calls for concrete parser types
- 3 fragmentation regression tests covering requestParser, ENSParser, ENHParser

## Affected Sites

| Site | Parser | Fix |
|------|--------|-----|
| session.go:112 | requestParser | Direct Reset() |
| upstream.go:75 | ENHParser | Direct Reset() |
| ens/driver.go:174 | ENSParser | resetIfSupported() |
| enh/driver.go:174 | ENHParser | resetIfSupported() |
| northbound/enh/listener.go:206 | ENHParser | resetIfSupported() |
| northbound/ens/listener.go:206 | ENSParser | resetIfSupported() |

## Root Cause

All three parser types retained stale internal state (pending bytes, escape flags) when a read timeout occurred mid-parse. On the next read attempt, the parser resumed with stale state, interpreting the first byte of the new frame as byte2 of an incomplete previous frame, producing corrupted output.

## Test Evidence

```
GOWORK=off go test -race -count=1 ./internal/adapterproxy/... ./internal/southbound/enh/... ./internal/southbound/ens/... ./internal/northbound/enh/... ./internal/northbound/ens/...
ok  internal/adapterproxy  1.306s
ok  internal/southbound/enh  1.035s
ok  internal/southbound/ens  1.035s
ok  internal/northbound/enh  1.166s
ok  internal/northbound/ens  1.169s
```

Fixes #78