### PR TITLE
Proxy: preserve reconstructible telegram context for northbound ENS observer sessions

### DIFF
--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1609,10 +1609,6 @@ func (server *Server) deliverUpstreamError(frame downstream.Frame) {
 	server.mutex.Unlock()
 
 	if owner != 0 {
-		observerFrames, skipPendingID := server.takeObserverReplayForAbort()
-		if len(observerFrames) > 0 {
-			server.broadcastObserverFrames(observerFrames, skipPendingID)
-		}
 		winner := byte(0x00)
 		if len(frame.Payload) == 1 {
 			winner = frame.Payload[0]
@@ -1632,10 +1628,6 @@ func (server *Server) deliverUpstreamFailed(frame downstream.Frame) {
 	server.mutex.Unlock()
 
 	if owner != 0 {
-		observerFrames, skipPendingID := server.takeObserverReplayForAbort()
-		if len(observerFrames) > 0 {
-			server.broadcastObserverFrames(observerFrames, skipPendingID)
-		}
 		server.reply(owner, frame)
 		server.releaseBusIfOwner(owner)
 		return
@@ -1645,10 +1637,22 @@ func (server *Server) deliverUpstreamFailed(frame downstream.Frame) {
 }
 
 func (server *Server) releaseBusIfOwner(sessionID uint64) {
+	var observerFrames []downstream.Frame
+	var sessions []*session
+
 	server.mutex.Lock()
 	if server.busOwner != sessionID {
 		server.mutex.Unlock()
 		return
+	}
+	if len(server.ownerObserverSeen) > 0 {
+		observerFrames = appendRawObserverFrames(nil, server.ownerObserverSeen)
+		for _, sess := range server.sessions {
+			if sess.id == sessionID {
+				continue
+			}
+			sessions = append(sessions, sess)
+		}
 	}
 	server.busOwner = 0
 	server.busOwnerInitiator = 0
@@ -1658,6 +1662,18 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 	server.busDirty = false
 	server.busOwned = time.Time{}
 	server.mutex.Unlock()
+
+	if len(observerFrames) > 0 {
+		skipPendingID := server.pendingUDPPlainStartSessionID()
+		for _, sess := range sessions {
+			if sess.id == skipPendingID {
+				continue
+			}
+			for _, frame := range observerFrames {
+				server.enqueueOrClose(sess, frame, "broadcast_observer_release")
+			}
+		}
+	}
 
 	server.releaseBusToken()
 }

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1427,7 +1427,11 @@ func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.F
 	server.mutex.Lock()
 	owner := server.busOwner
 	suppress := false
+	var frames []downstream.Frame
 	if symbol == ebusSyn {
+		if len(server.ownerObserverReplay) > 0 {
+			frames = append([]downstream.Frame(nil), server.ownerObserverReplay...)
+		}
 		server.ownerObserverReplay = nil
 		if owner != 0 {
 			server.ownerObserverAtStart = true
@@ -1436,13 +1440,20 @@ func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.F
 		}
 		server.ownerObserverSuppressCount = 0
 		server.mutex.Unlock()
-		return nil, 0, false
+		if len(frames) == 0 {
+			return nil, 0, false
+		}
+		return frames, server.pendingUDPPlainStartSessionID(), false
 	}
-	frames := append([]downstream.Frame(nil), server.ownerObserverReplay...)
-	server.ownerObserverReplay = nil
 	if server.ownerObserverSuppressCount > 0 {
 		server.ownerObserverSuppressCount--
 		suppress = true
+		server.mutex.Unlock()
+		return nil, 0, suppress
+	}
+	if len(server.ownerObserverReplay) > 0 {
+		frames = append([]downstream.Frame(nil), server.ownerObserverReplay...)
+		server.ownerObserverReplay = nil
 	}
 	server.mutex.Unlock()
 

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -77,8 +77,8 @@ type Server struct {
 	busOwner              uint64
 	busOwnerInitiator     byte
 	ownerObserverAtStart  bool
-	ownerObserverReplay   []downstream.Frame
-	ownerObserverSuppress []byte
+	ownerObserverExpected []byte
+	ownerObserverSeen     []byte
 	busDirty              bool
 	busOwned              time.Time
 
@@ -1429,36 +1429,51 @@ func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.F
 	suppress := false
 	var frames []downstream.Frame
 	if symbol == ebusSyn {
-		if len(server.ownerObserverReplay) > 0 {
-			frames = append([]downstream.Frame(nil), server.ownerObserverReplay...)
+		if len(server.ownerObserverSeen) > 0 {
+			frames = appendObserverReplayFrames(
+				frames,
+				server.busOwnerInitiator,
+				server.ownerObserverSeen,
+				server.ownerObserverAtStart,
+			)
 		}
-		server.ownerObserverReplay = nil
+		server.ownerObserverExpected = nil
+		server.ownerObserverSeen = nil
 		if owner != 0 {
 			server.ownerObserverAtStart = true
 		} else {
 			server.ownerObserverAtStart = false
 		}
-		server.ownerObserverSuppress = nil
 		server.mutex.Unlock()
 		if len(frames) == 0 {
 			return nil, 0, false
 		}
 		return frames, server.pendingUDPPlainStartSessionID(), false
 	}
-	if len(server.ownerObserverSuppress) > 0 {
-		if symbol == server.ownerObserverSuppress[0] {
-			server.ownerObserverSuppress = server.ownerObserverSuppress[1:]
+	if len(server.ownerObserverExpected) > 0 {
+		if symbol == server.ownerObserverExpected[0] {
+			server.ownerObserverExpected = server.ownerObserverExpected[1:]
+			server.ownerObserverSeen = append(server.ownerObserverSeen, symbol)
 			suppress = true
 			server.mutex.Unlock()
 			return nil, 0, suppress
 		}
-		server.ownerObserverReplay = nil
-		server.ownerObserverSuppress = nil
+		if len(server.ownerObserverSeen) > 0 {
+			frames = appendRawObserverFrames(frames, server.ownerObserverSeen)
+		}
+		server.ownerObserverExpected = nil
+		server.ownerObserverSeen = nil
 		server.ownerObserverAtStart = false
 	}
-	if len(server.ownerObserverReplay) > 0 {
-		frames = append([]downstream.Frame(nil), server.ownerObserverReplay...)
-		server.ownerObserverReplay = nil
+	if len(server.ownerObserverSeen) > 0 {
+		frames = appendObserverReplayFrames(
+			frames,
+			server.busOwnerInitiator,
+			server.ownerObserverSeen,
+			server.ownerObserverAtStart,
+		)
+		server.ownerObserverSeen = nil
+		server.ownerObserverAtStart = false
 	}
 	server.mutex.Unlock()
 
@@ -1626,8 +1641,8 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 	server.busOwner = 0
 	server.busOwnerInitiator = 0
 	server.ownerObserverAtStart = false
-	server.ownerObserverReplay = nil
-	server.ownerObserverSuppress = nil
+	server.ownerObserverExpected = nil
+	server.ownerObserverSeen = nil
 	server.busDirty = false
 	server.busOwned = time.Time{}
 	server.mutex.Unlock()
@@ -1640,8 +1655,8 @@ func (server *Server) setBusOwner(sessionID uint64, initiator byte) {
 	server.busOwner = sessionID
 	server.busOwnerInitiator = initiator
 	server.ownerObserverAtStart = true
-	server.ownerObserverReplay = nil
-	server.ownerObserverSuppress = nil
+	server.ownerObserverExpected = nil
+	server.ownerObserverSeen = nil
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.mutex.Unlock()
@@ -1653,44 +1668,45 @@ func (server *Server) queueOwnerObserverReplay(sessionID uint64, data byte) bool
 	if server.busOwner != sessionID {
 		return false
 	}
-	if server.ownerObserverAtStart {
-		server.ownerObserverReplay = append(server.ownerObserverReplay, downstream.Frame{
-			Command: byte(southboundenh.ENHResReceived),
-			Payload: []byte{server.busOwnerInitiator},
-		})
-		server.ownerObserverAtStart = false
-	}
-	server.ownerObserverReplay = append(server.ownerObserverReplay, downstream.Frame{
-		Command: byte(southboundenh.ENHResReceived),
-		Payload: []byte{data},
-	})
-	server.ownerObserverSuppress = append(server.ownerObserverSuppress, data)
+	server.ownerObserverExpected = append(server.ownerObserverExpected, data)
 	return true
 }
 
 func (server *Server) rollbackOwnerObserverReplay(sessionID uint64) {
 	server.mutex.Lock()
 	defer server.mutex.Unlock()
-	if server.busOwner != sessionID || len(server.ownerObserverReplay) == 0 {
+	if server.busOwner != sessionID || len(server.ownerObserverExpected) == 0 {
 		return
 	}
+	server.ownerObserverExpected = server.ownerObserverExpected[:len(server.ownerObserverExpected)-1]
+}
 
-	if len(server.ownerObserverSuppress) > 0 {
-		server.ownerObserverSuppress = server.ownerObserverSuppress[:len(server.ownerObserverSuppress)-1]
+func appendObserverReplayFrames(
+	dst []downstream.Frame,
+	initiator byte,
+	symbols []byte,
+	includeInitiator bool,
+) []downstream.Frame {
+	if len(symbols) == 0 {
+		return dst
 	}
-	server.ownerObserverReplay = server.ownerObserverReplay[:len(server.ownerObserverReplay)-1]
+	if includeInitiator {
+		dst = append(dst, downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{initiator},
+		})
+	}
+	return appendRawObserverFrames(dst, symbols)
+}
 
-	if len(server.ownerObserverReplay) > 0 {
-		last := server.ownerObserverReplay[len(server.ownerObserverReplay)-1]
-		if southboundenh.ENHCommand(last.Command) == southboundenh.ENHResReceived &&
-			len(last.Payload) == 1 &&
-			last.Payload[0] == server.busOwnerInitiator {
-			server.ownerObserverReplay = server.ownerObserverReplay[:len(server.ownerObserverReplay)-1]
-			server.ownerObserverAtStart = true
-		}
-	} else {
-		server.ownerObserverAtStart = true
+func appendRawObserverFrames(dst []downstream.Frame, symbols []byte) []downstream.Frame {
+	for _, symbol := range symbols {
+		dst = append(dst, downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		})
 	}
+	return dst
 }
 
 func (server *Server) pendingUDPPlainStartSessionID() uint64 {

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1406,7 +1406,7 @@ func (server *Server) clearPendingInfo(sessionID uint64) {
 }
 
 func (server *Server) observerPrefixFrameForWireSymbol(symbol byte) (downstream.Frame, uint64, uint64, bool) {
-	if symbol == ebusSyn || isInitiatorAddress(symbol) {
+	if symbol == ebusSyn {
 		return downstream.Frame{}, 0, 0, false
 	}
 
@@ -1422,6 +1422,9 @@ func (server *Server) observerPrefixFrameForWireSymbol(symbol byte) (downstream.
 	initiator := server.busOwnerInitiator
 	server.mutex.Unlock()
 	if owner == 0 || initiator == 0 {
+		return downstream.Frame{}, 0, 0, false
+	}
+	if symbol == initiator {
 		return downstream.Frame{}, 0, 0, false
 	}
 

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -73,10 +73,11 @@ type Server struct {
 	observedInitiatorAt map[byte]time.Time
 	collisionBySession  map[uint64]byte
 
-	busToken chan struct{}
-	busOwner uint64
-	busDirty bool
-	busOwned time.Time
+	busToken          chan struct{}
+	busOwner          uint64
+	busOwnerInitiator byte
+	busDirty          bool
+	busOwned          time.Time
 
 	pendingStartMu sync.Mutex
 	pendingStart   *pendingStart
@@ -551,11 +552,7 @@ func (server *Server) handleStart(ctx context.Context, sessionID uint64, initiat
 		}
 		switch southboundenh.ENHCommand(response.Command) {
 		case southboundenh.ENHResStarted:
-			server.mutex.Lock()
-			server.busOwner = sessionID
-			server.busDirty = true
-			server.busOwned = time.Now().UTC()
-			server.mutex.Unlock()
+			server.setBusOwner(sessionID, initiator)
 			server.clearSessionCollision(sessionID)
 			return
 		default:
@@ -702,11 +699,7 @@ func (server *Server) handleStartUDPPlain(ctx context.Context, sessionID uint64,
 			server.clearPendingStart(sessionID)
 			switch southboundenh.ENHCommand(response.Command) {
 			case southboundenh.ENHResStarted:
-				server.mutex.Lock()
-				server.busOwner = sessionID
-				server.busDirty = true
-				server.busOwned = time.Now().UTC()
-				server.mutex.Unlock()
+				server.setBusOwner(sessionID, initiator)
 				server.clearSessionCollision(sessionID)
 				server.reply(sessionID, downstream.Frame{
 					Command: byte(southboundenh.ENHResStarted),
@@ -759,11 +752,7 @@ func (server *Server) handleStartUDPPlain(ctx context.Context, sessionID uint64,
 			if server.cfg.Debug {
 				log.Printf("session=%d start_timeout_fallback=true", sessionID)
 			}
-			server.mutex.Lock()
-			server.busOwner = sessionID
-			server.busDirty = true
-			server.busOwned = time.Now().UTC()
-			server.mutex.Unlock()
+			server.setBusOwner(sessionID, initiator)
 			server.clearSessionCollision(sessionID)
 			server.reply(sessionID, downstream.Frame{
 				Command: byte(southboundenh.ENHResStarted),
@@ -963,11 +952,7 @@ func (server *Server) forwardUDPPlainDatagram(ctx context.Context, payload []byt
 		if err := server.startUDPPlainBridge(ctx, initiator); err != nil {
 			return err
 		}
-		server.mutex.Lock()
-		server.busOwner = udpBridgeOwnerID
-		server.busDirty = true
-		server.busOwned = time.Now().UTC()
-		server.mutex.Unlock()
+		server.setBusOwner(udpBridgeOwnerID, initiator)
 		releaseToken = false
 		payload = payload[1:]
 		if len(payload) == 0 {
@@ -1089,6 +1074,8 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 				server.upstreamFeatures.Store(uint32(frame.Payload[0]))
 			}
 			if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResReceived && len(frame.Payload) == 1 {
+				prefixFrame, prefixSkipOwner, prefixSkipPending, injectPrefix :=
+					server.observerPrefixFrameForWireSymbol(frame.Payload[0])
 				server.lastWireRXAtNano.Store(time.Now().UTC().UnixNano())
 				if server.cfg.Debug {
 					log.Printf("wire_rx symbol=0x%02X", frame.Payload[0])
@@ -1105,6 +1092,16 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 				}
 
 				if server.shouldUseWireArbitrationResult() && server.isStartPending() && server.deliverPendingStartFromArbByte(frame.Payload[0]) {
+					continue
+				}
+
+				if injectPrefix {
+					server.broadcastReceivedWithObserverPrefix(
+						prefixFrame,
+						prefixSkipOwner,
+						prefixSkipPending,
+						frame,
+					)
 					continue
 				}
 			}
@@ -1408,6 +1405,39 @@ func (server *Server) clearPendingInfo(sessionID uint64) {
 	server.pendingInfoMu.Unlock()
 }
 
+func (server *Server) observerPrefixFrameForWireSymbol(symbol byte) (downstream.Frame, uint64, uint64, bool) {
+	if symbol == ebusSyn || isInitiatorAddress(symbol) {
+		return downstream.Frame{}, 0, 0, false
+	}
+
+	server.observedMu.Lock()
+	atTelegramStart := server.startOfTelegram
+	server.observedMu.Unlock()
+	if !atTelegramStart {
+		return downstream.Frame{}, 0, 0, false
+	}
+
+	server.mutex.Lock()
+	owner := server.busOwner
+	initiator := server.busOwnerInitiator
+	server.mutex.Unlock()
+	if owner == 0 || initiator == 0 {
+		return downstream.Frame{}, 0, 0, false
+	}
+
+	var pendingSessionID uint64
+	server.pendingStartMu.Lock()
+	if server.pendingStart != nil {
+		pendingSessionID = server.pendingStart.sessionID
+	}
+	server.pendingStartMu.Unlock()
+
+	return downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{initiator},
+	}, owner, pendingSessionID, true
+}
+
 func (server *Server) broadcast(frame downstream.Frame) {
 	server.mutex.Lock()
 	sessions := make([]*session, 0, len(server.sessions))
@@ -1417,6 +1447,27 @@ func (server *Server) broadcast(frame downstream.Frame) {
 	server.mutex.Unlock()
 
 	for _, sess := range sessions {
+		server.enqueueOrClose(sess, frame, "broadcast")
+	}
+}
+
+func (server *Server) broadcastReceivedWithObserverPrefix(
+	prefix downstream.Frame,
+	skipOwnerID uint64,
+	skipPendingID uint64,
+	frame downstream.Frame,
+) {
+	server.mutex.Lock()
+	sessions := make([]*session, 0, len(server.sessions))
+	for _, sess := range server.sessions {
+		sessions = append(sessions, sess)
+	}
+	server.mutex.Unlock()
+
+	for _, sess := range sessions {
+		if sess.id != skipOwnerID && sess.id != skipPendingID {
+			server.enqueueOrClose(sess, prefix, "broadcast_observer_prefix")
+		}
 		server.enqueueOrClose(sess, frame, "broadcast")
 	}
 }
@@ -1532,11 +1583,21 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 		return
 	}
 	server.busOwner = 0
+	server.busOwnerInitiator = 0
 	server.busDirty = false
 	server.busOwned = time.Time{}
 	server.mutex.Unlock()
 
 	server.releaseBusToken()
+}
+
+func (server *Server) setBusOwner(sessionID uint64, initiator byte) {
+	server.mutex.Lock()
+	server.busOwner = sessionID
+	server.busOwnerInitiator = initiator
+	server.busDirty = true
+	server.busOwned = time.Now().UTC()
+	server.mutex.Unlock()
 }
 
 func (server *Server) releaseBusIfIdleSyn() {

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -73,14 +73,14 @@ type Server struct {
 	observedInitiatorAt map[byte]time.Time
 	collisionBySession  map[uint64]byte
 
-	busToken                   chan struct{}
-	busOwner                   uint64
-	busOwnerInitiator          byte
-	ownerObserverAtStart       bool
-	ownerObserverReplay        []downstream.Frame
-	ownerObserverSuppressCount int
-	busDirty                   bool
-	busOwned                   time.Time
+	busToken              chan struct{}
+	busOwner              uint64
+	busOwnerInitiator     byte
+	ownerObserverAtStart  bool
+	ownerObserverReplay   []downstream.Frame
+	ownerObserverSuppress []byte
+	busDirty              bool
+	busOwned              time.Time
 
 	pendingStartMu sync.Mutex
 	pendingStart   *pendingStart
@@ -1438,18 +1438,23 @@ func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.F
 		} else {
 			server.ownerObserverAtStart = false
 		}
-		server.ownerObserverSuppressCount = 0
+		server.ownerObserverSuppress = nil
 		server.mutex.Unlock()
 		if len(frames) == 0 {
 			return nil, 0, false
 		}
 		return frames, server.pendingUDPPlainStartSessionID(), false
 	}
-	if server.ownerObserverSuppressCount > 0 {
-		server.ownerObserverSuppressCount--
-		suppress = true
-		server.mutex.Unlock()
-		return nil, 0, suppress
+	if len(server.ownerObserverSuppress) > 0 {
+		if symbol == server.ownerObserverSuppress[0] {
+			server.ownerObserverSuppress = server.ownerObserverSuppress[1:]
+			suppress = true
+			server.mutex.Unlock()
+			return nil, 0, suppress
+		}
+		server.ownerObserverReplay = nil
+		server.ownerObserverSuppress = nil
+		server.ownerObserverAtStart = false
 	}
 	if len(server.ownerObserverReplay) > 0 {
 		frames = append([]downstream.Frame(nil), server.ownerObserverReplay...)
@@ -1622,7 +1627,7 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 	server.busOwnerInitiator = 0
 	server.ownerObserverAtStart = false
 	server.ownerObserverReplay = nil
-	server.ownerObserverSuppressCount = 0
+	server.ownerObserverSuppress = nil
 	server.busDirty = false
 	server.busOwned = time.Time{}
 	server.mutex.Unlock()
@@ -1636,7 +1641,7 @@ func (server *Server) setBusOwner(sessionID uint64, initiator byte) {
 	server.busOwnerInitiator = initiator
 	server.ownerObserverAtStart = true
 	server.ownerObserverReplay = nil
-	server.ownerObserverSuppressCount = 0
+	server.ownerObserverSuppress = nil
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.mutex.Unlock()
@@ -1659,7 +1664,7 @@ func (server *Server) queueOwnerObserverReplay(sessionID uint64, data byte) bool
 		Command: byte(southboundenh.ENHResReceived),
 		Payload: []byte{data},
 	})
-	server.ownerObserverSuppressCount++
+	server.ownerObserverSuppress = append(server.ownerObserverSuppress, data)
 	return true
 }
 
@@ -1670,8 +1675,8 @@ func (server *Server) rollbackOwnerObserverReplay(sessionID uint64) {
 		return
 	}
 
-	if server.ownerObserverSuppressCount > 0 {
-		server.ownerObserverSuppressCount--
+	if len(server.ownerObserverSuppress) > 0 {
+		server.ownerObserverSuppress = server.ownerObserverSuppress[:len(server.ownerObserverSuppress)-1]
 	}
 	server.ownerObserverReplay = server.ownerObserverReplay[:len(server.ownerObserverReplay)-1]
 

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1605,6 +1605,10 @@ func (server *Server) deliverUpstreamError(frame downstream.Frame) {
 	server.mutex.Unlock()
 
 	if owner != 0 {
+		observerFrames, skipPendingID := server.takeObserverReplayForAbort()
+		if len(observerFrames) > 0 {
+			server.broadcastObserverFrames(observerFrames, skipPendingID)
+		}
 		winner := byte(0x00)
 		if len(frame.Payload) == 1 {
 			winner = frame.Payload[0]
@@ -1624,6 +1628,10 @@ func (server *Server) deliverUpstreamFailed(frame downstream.Frame) {
 	server.mutex.Unlock()
 
 	if owner != 0 {
+		observerFrames, skipPendingID := server.takeObserverReplayForAbort()
+		if len(observerFrames) > 0 {
+			server.broadcastObserverFrames(observerFrames, skipPendingID)
+		}
 		server.reply(owner, frame)
 		server.releaseBusIfOwner(owner)
 		return
@@ -1707,6 +1715,24 @@ func appendRawObserverFrames(dst []downstream.Frame, symbols []byte) []downstrea
 		})
 	}
 	return dst
+}
+
+func (server *Server) takeObserverReplayForAbort() ([]downstream.Frame, uint64) {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+
+	if len(server.ownerObserverSeen) == 0 {
+		server.ownerObserverExpected = nil
+		server.ownerObserverSeen = nil
+		server.ownerObserverAtStart = false
+		return nil, 0
+	}
+
+	frames := appendRawObserverFrames(nil, server.ownerObserverSeen)
+	server.ownerObserverExpected = nil
+	server.ownerObserverSeen = nil
+	server.ownerObserverAtStart = false
+	return frames, server.pendingUDPPlainStartSessionID()
 }
 
 func (server *Server) pendingUDPPlainStartSessionID() uint64 {

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1434,7 +1434,7 @@ func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.F
 	var frames []downstream.Frame
 	if symbol == ebusSyn {
 		if len(server.ownerObserverSeen) > 0 {
-			frames = appendObserverReplayFrames(
+			frames = appendObserverRequestSegmentFrames(
 				frames,
 				server.busOwnerInitiator,
 				server.ownerObserverSeen,
@@ -1452,7 +1452,7 @@ func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.F
 		if len(frames) == 0 {
 			return nil, 0, false
 		}
-		return frames, server.pendingUDPPlainStartSessionID(), false
+		return frames, server.pendingUDPPlainStartSessionID(), true
 	}
 	if len(server.ownerObserverExpected) > 0 {
 		if symbol == server.ownerObserverExpected[0] {
@@ -1470,7 +1470,7 @@ func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.F
 		server.ownerObserverAtStart = false
 	}
 	if len(server.ownerObserverSeen) > 0 {
-		frames = appendObserverReplayFrames(
+		frames = appendObserverRequestSegmentFrames(
 			frames,
 			server.busOwnerInitiator,
 			server.ownerObserverSeen,
@@ -1725,6 +1725,16 @@ func appendObserverReplayFrames(
 		})
 	}
 	return appendRawObserverFrames(dst, symbols)
+}
+
+func appendObserverRequestSegmentFrames(
+	dst []downstream.Frame,
+	initiator byte,
+	symbols []byte,
+	includeInitiator bool,
+) []downstream.Frame {
+	dst = appendObserverReplayFrames(dst, initiator, symbols, includeInitiator)
+	return appendRawObserverFrames(dst, []byte{ebusSyn})
 }
 
 func appendRawObserverFrames(dst []downstream.Frame, symbols []byte) []downstream.Frame {

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -73,16 +73,14 @@ type Server struct {
 	observedInitiatorAt map[byte]time.Time
 	collisionBySession  map[uint64]byte
 
-	busToken                     chan struct{}
-	busOwner                     uint64
-	busOwnerInitiator            byte
-	busOwnerShorthandPending     bool
-	busOwnerShorthandExpectedLen int
-	busOwnerShorthandExpected    [2]byte
-	busOwnerShorthandObservedLen int
-	busOwnerShorthandObserved    [2]byte
-	busDirty                     bool
-	busOwned                     time.Time
+	busToken                   chan struct{}
+	busOwner                   uint64
+	busOwnerInitiator          byte
+	ownerObserverAtStart       bool
+	ownerObserverReplay        []downstream.Frame
+	ownerObserverSuppressCount int
+	busDirty                   bool
+	busOwned                   time.Time
 
 	pendingStartMu sync.Mutex
 	pendingStart   *pendingStart
@@ -828,11 +826,12 @@ func (server *Server) handleSend(sessionID uint64, data byte) {
 		return
 	}
 
+	queuedObserverFrames := server.queueOwnerObserverReplay(sessionID, data)
+
 	server.mutex.Lock()
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.mutex.Unlock()
-	server.noteOwnerShorthandSend(sessionID, data)
 
 	sendFrame := downstream.Frame{
 		Command: byte(southboundenh.ENHReqSend),
@@ -843,6 +842,9 @@ func (server *Server) handleSend(sessionID uint64, data byte) {
 	}
 	server.logWireTX(data)
 	if err := server.upstream.WriteFrame(sendFrame); err != nil {
+		if queuedObserverFrames {
+			server.rollbackOwnerObserverReplay(sessionID)
+		}
 		server.reply(sessionID, downstream.Frame{
 			Command: byte(southboundenh.ENHResErrorHost),
 			Payload: []byte{0x00},
@@ -1080,7 +1082,6 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 				server.upstreamFeatures.Store(uint32(frame.Payload[0]))
 			}
 			if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResReceived && len(frame.Payload) == 1 {
-				atTelegramStart := server.isAtTelegramStart()
 				server.lastWireRXAtNano.Store(time.Now().UTC().UnixNano())
 				if server.cfg.Debug {
 					log.Printf("wire_rx symbol=0x%02X", frame.Payload[0])
@@ -1100,7 +1101,12 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 					continue
 				}
 
-				if server.handleObserverPrefixForReceived(frame, atTelegramStart) {
+				observerFrames, skipPendingID, suppressObservers := server.takeObserverReplayForReceived(frame.Payload[0])
+				if len(observerFrames) > 0 {
+					server.broadcastObserverFrames(observerFrames, skipPendingID)
+				}
+				if suppressObservers {
+					server.broadcastReceivedToOwner(frame, server.currentBusOwner())
 					continue
 				}
 			}
@@ -1404,58 +1410,6 @@ func (server *Server) clearPendingInfo(sessionID uint64) {
 	server.pendingInfoMu.Unlock()
 }
 
-func (server *Server) isAtTelegramStart() bool {
-	server.observedMu.Lock()
-	atTelegramStart := server.startOfTelegram
-	server.observedMu.Unlock()
-	return atTelegramStart
-}
-
-func (server *Server) handleObserverPrefixForReceived(frame downstream.Frame, atTelegramStart bool) bool {
-	if len(frame.Payload) != 1 {
-		return false
-	}
-	symbol := frame.Payload[0]
-	if symbol == ebusSyn {
-		server.clearOwnerShorthandState()
-		return false
-	}
-
-	owner, initiator, pending, expectedLen, observedLen := server.ownerShorthandState()
-	if owner == 0 || initiator == 0 || !pending || expectedLen < 2 {
-		return false
-	}
-	if observedLen == 0 && !atTelegramStart {
-		return false
-	}
-
-	observerFrames, injectPrefix, holdOwnerOnly, matched := server.advanceOwnerShorthandProbe(symbol)
-	if !matched {
-		return false
-	}
-
-	pendingSessionID := server.pendingUDPPlainStartSessionID()
-	server.broadcastReceivedToOwner(frame, owner)
-	if holdOwnerOnly {
-		return true
-	}
-	if injectPrefix {
-		server.broadcastReceivedFramesWithObserverPrefix(
-			downstream.Frame{
-				Command: byte(southboundenh.ENHResReceived),
-				Payload: []byte{initiator},
-			},
-			owner,
-			pendingSessionID,
-			observerFrames,
-		)
-		return true
-	}
-
-	server.broadcastReceivedFramesToObservers(observerFrames, owner, pendingSessionID)
-	return true
-}
-
 func (server *Server) broadcast(frame downstream.Frame) {
 	server.mutex.Lock()
 	sessions := make([]*session, 0, len(server.sessions))
@@ -1469,58 +1423,37 @@ func (server *Server) broadcast(frame downstream.Frame) {
 	}
 }
 
-func (server *Server) broadcastReceivedWithObserverPrefix(
-	prefix downstream.Frame,
-	skipOwnerID uint64,
-	skipPendingID uint64,
-	frame downstream.Frame,
-) {
+func (server *Server) takeObserverReplayForReceived(symbol byte) ([]downstream.Frame, uint64, bool) {
 	server.mutex.Lock()
-	sessions := make([]*session, 0, len(server.sessions))
-	for _, sess := range server.sessions {
-		sessions = append(sessions, sess)
+	owner := server.busOwner
+	suppress := false
+	if symbol == ebusSyn {
+		server.ownerObserverReplay = nil
+		if owner != 0 {
+			server.ownerObserverAtStart = true
+		} else {
+			server.ownerObserverAtStart = false
+		}
+		server.ownerObserverSuppressCount = 0
+		server.mutex.Unlock()
+		return nil, 0, false
+	}
+	frames := append([]downstream.Frame(nil), server.ownerObserverReplay...)
+	server.ownerObserverReplay = nil
+	if server.ownerObserverSuppressCount > 0 {
+		server.ownerObserverSuppressCount--
+		suppress = true
 	}
 	server.mutex.Unlock()
 
-	for _, sess := range sessions {
-		if sess.id != skipOwnerID && sess.id != skipPendingID {
-			server.enqueueOrClose(sess, prefix, "broadcast_observer_prefix")
-		}
-		server.enqueueOrClose(sess, frame, "broadcast")
-	}
-}
-
-func (server *Server) broadcastReceivedFramesWithObserverPrefix(
-	prefix downstream.Frame,
-	skipOwnerID uint64,
-	skipPendingID uint64,
-	frames []downstream.Frame,
-) {
 	if len(frames) == 0 {
-		return
+		return nil, 0, suppress
 	}
-
-	server.mutex.Lock()
-	sessions := make([]*session, 0, len(server.sessions))
-	for _, sess := range server.sessions {
-		sessions = append(sessions, sess)
-	}
-	server.mutex.Unlock()
-
-	for _, sess := range sessions {
-		if sess.id == skipOwnerID || sess.id == skipPendingID {
-			continue
-		}
-		server.enqueueOrClose(sess, prefix, "broadcast_observer_prefix")
-		for _, frame := range frames {
-			server.enqueueOrClose(sess, frame, "broadcast_observer_buffer")
-		}
-	}
+	return frames, server.pendingUDPPlainStartSessionID(), suppress
 }
 
-func (server *Server) broadcastReceivedFramesToObservers(
+func (server *Server) broadcastObserverFrames(
 	frames []downstream.Frame,
-	skipOwnerID uint64,
 	skipPendingID uint64,
 ) {
 	if len(frames) == 0 {
@@ -1528,6 +1461,7 @@ func (server *Server) broadcastReceivedFramesToObservers(
 	}
 
 	server.mutex.Lock()
+	ownerID := server.busOwner
 	sessions := make([]*session, 0, len(server.sessions))
 	for _, sess := range server.sessions {
 		sessions = append(sessions, sess)
@@ -1535,13 +1469,19 @@ func (server *Server) broadcastReceivedFramesToObservers(
 	server.mutex.Unlock()
 
 	for _, sess := range sessions {
-		if sess.id == skipOwnerID || sess.id == skipPendingID {
+		if sess.id == ownerID || sess.id == skipPendingID {
 			continue
 		}
 		for _, frame := range frames {
-			server.enqueueOrClose(sess, frame, "broadcast_observer_buffer")
+			server.enqueueOrClose(sess, frame, "broadcast_observer_prefix")
 		}
 	}
+}
+
+func (server *Server) currentBusOwner() uint64 {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+	return server.busOwner
 }
 
 func (server *Server) broadcastReceivedToOwner(frame downstream.Frame, ownerID uint64) {
@@ -1669,11 +1609,9 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 	}
 	server.busOwner = 0
 	server.busOwnerInitiator = 0
-	server.busOwnerShorthandPending = false
-	server.busOwnerShorthandExpectedLen = 0
-	server.busOwnerShorthandExpected = [2]byte{}
-	server.busOwnerShorthandObservedLen = 0
-	server.busOwnerShorthandObserved = [2]byte{}
+	server.ownerObserverAtStart = false
+	server.ownerObserverReplay = nil
+	server.ownerObserverSuppressCount = 0
 	server.busDirty = false
 	server.busOwned = time.Time{}
 	server.mutex.Unlock()
@@ -1685,51 +1623,58 @@ func (server *Server) setBusOwner(sessionID uint64, initiator byte) {
 	server.mutex.Lock()
 	server.busOwner = sessionID
 	server.busOwnerInitiator = initiator
-	server.busOwnerShorthandPending = false
-	server.busOwnerShorthandExpectedLen = 0
-	server.busOwnerShorthandExpected = [2]byte{}
-	server.busOwnerShorthandObservedLen = 0
-	server.busOwnerShorthandObserved = [2]byte{}
+	server.ownerObserverAtStart = true
+	server.ownerObserverReplay = nil
+	server.ownerObserverSuppressCount = 0
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.mutex.Unlock()
 }
 
-func (server *Server) noteOwnerShorthandSend(sessionID uint64, firstByte byte) {
-	server.observedMu.Lock()
-	atTelegramStart := server.startOfTelegram
-	server.observedMu.Unlock()
-	if !atTelegramStart {
-		return
-	}
-
+func (server *Server) queueOwnerObserverReplay(sessionID uint64, data byte) bool {
 	server.mutex.Lock()
 	defer server.mutex.Unlock()
 	if server.busOwner != sessionID {
-		return
+		return false
 	}
-	if server.busOwnerShorthandExpectedLen >= len(server.busOwnerShorthandExpected) {
-		return
+	if server.ownerObserverAtStart {
+		server.ownerObserverReplay = append(server.ownerObserverReplay, downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{server.busOwnerInitiator},
+		})
+		server.ownerObserverAtStart = false
 	}
-	server.busOwnerShorthandPending = true
-	server.busOwnerShorthandExpected[server.busOwnerShorthandExpectedLen] = firstByte
-	server.busOwnerShorthandExpectedLen++
+	server.ownerObserverReplay = append(server.ownerObserverReplay, downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{data},
+	})
+	server.ownerObserverSuppressCount++
+	return true
 }
 
-func (server *Server) clearOwnerShorthandState() {
-	server.mutex.Lock()
-	server.busOwnerShorthandPending = false
-	server.busOwnerShorthandExpectedLen = 0
-	server.busOwnerShorthandExpected = [2]byte{}
-	server.busOwnerShorthandObservedLen = 0
-	server.busOwnerShorthandObserved = [2]byte{}
-	server.mutex.Unlock()
-}
-
-func (server *Server) ownerShorthandState() (uint64, byte, bool, int, int) {
+func (server *Server) rollbackOwnerObserverReplay(sessionID uint64) {
 	server.mutex.Lock()
 	defer server.mutex.Unlock()
-	return server.busOwner, server.busOwnerInitiator, server.busOwnerShorthandPending, server.busOwnerShorthandExpectedLen, server.busOwnerShorthandObservedLen
+	if server.busOwner != sessionID || len(server.ownerObserverReplay) == 0 {
+		return
+	}
+
+	if server.ownerObserverSuppressCount > 0 {
+		server.ownerObserverSuppressCount--
+	}
+	server.ownerObserverReplay = server.ownerObserverReplay[:len(server.ownerObserverReplay)-1]
+
+	if len(server.ownerObserverReplay) > 0 {
+		last := server.ownerObserverReplay[len(server.ownerObserverReplay)-1]
+		if southboundenh.ENHCommand(last.Command) == southboundenh.ENHResReceived &&
+			len(last.Payload) == 1 &&
+			last.Payload[0] == server.busOwnerInitiator {
+			server.ownerObserverReplay = server.ownerObserverReplay[:len(server.ownerObserverReplay)-1]
+			server.ownerObserverAtStart = true
+		}
+	} else {
+		server.ownerObserverAtStart = true
+	}
 }
 
 func (server *Server) pendingUDPPlainStartSessionID() uint64 {
@@ -1739,64 +1684,6 @@ func (server *Server) pendingUDPPlainStartSessionID() uint64 {
 		return server.pendingStart.sessionID
 	}
 	return 0
-}
-
-func (server *Server) advanceOwnerShorthandProbe(symbol byte) ([]downstream.Frame, bool, bool, bool) {
-	server.mutex.Lock()
-	defer server.mutex.Unlock()
-
-	if !server.busOwnerShorthandPending || server.busOwnerShorthandExpectedLen < 2 {
-		return nil, false, false, false
-	}
-	if server.busOwnerShorthandObservedLen >= len(server.busOwnerShorthandObserved) {
-		server.busOwnerShorthandPending = false
-		server.busOwnerShorthandExpectedLen = 0
-		server.busOwnerShorthandExpected = [2]byte{}
-		server.busOwnerShorthandObservedLen = 0
-		server.busOwnerShorthandObserved = [2]byte{}
-		return nil, false, false, false
-	}
-
-	index := server.busOwnerShorthandObservedLen
-	server.busOwnerShorthandObserved[index] = symbol
-	server.busOwnerShorthandObservedLen++
-
-	if symbol != server.busOwnerShorthandExpected[index] {
-		observedLen := server.busOwnerShorthandObservedLen
-		observedFrames := shorthandObservedFrames(server.busOwnerShorthandObserved[:observedLen])
-		server.busOwnerShorthandPending = false
-		server.busOwnerShorthandExpectedLen = 0
-		server.busOwnerShorthandExpected = [2]byte{}
-		server.busOwnerShorthandObservedLen = 0
-		server.busOwnerShorthandObserved = [2]byte{}
-		if index == 0 {
-			return nil, false, false, false
-		}
-		return observedFrames, false, false, true
-	}
-
-	if server.busOwnerShorthandObservedLen < 2 {
-		return nil, false, true, true
-	}
-
-	frames := shorthandObservedFrames(server.busOwnerShorthandObserved[:server.busOwnerShorthandObservedLen])
-	server.busOwnerShorthandPending = false
-	server.busOwnerShorthandExpectedLen = 0
-	server.busOwnerShorthandExpected = [2]byte{}
-	server.busOwnerShorthandObservedLen = 0
-	server.busOwnerShorthandObserved = [2]byte{}
-	return frames, true, false, true
-}
-
-func shorthandObservedFrames(symbols []byte) []downstream.Frame {
-	frames := make([]downstream.Frame, 0, len(symbols))
-	for _, symbol := range symbols {
-		frames = append(frames, downstream.Frame{
-			Command: byte(southboundenh.ENHResReceived),
-			Payload: []byte{symbol},
-		})
-	}
-	return frames
 }
 
 func (server *Server) releaseBusIfIdleSyn() {

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1427,7 +1427,7 @@ func (server *Server) observerPrefixFrameForWireSymbol(symbol byte) (downstream.
 
 	var pendingSessionID uint64
 	server.pendingStartMu.Lock()
-	if server.pendingStart != nil {
+	if server.pendingStart != nil && server.pendingStart.mode == pendingStartModeUDPPlain {
 		pendingSessionID = server.pendingStart.sessionID
 	}
 	server.pendingStartMu.Unlock()

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -1071,6 +1071,10 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 				continue
 			}
 			if errors.Is(err, io.EOF) || isClosedNetworkError(err) {
+				observerFrames, skipPendingID := server.takeObserverReplayForAbort()
+				if len(observerFrames) > 0 {
+					server.broadcastObserverFrames(observerFrames, skipPendingID)
+				}
 				return
 			}
 			continue

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -73,13 +73,16 @@ type Server struct {
 	observedInitiatorAt map[byte]time.Time
 	collisionBySession  map[uint64]byte
 
-	busToken                   chan struct{}
-	busOwner                   uint64
-	busOwnerInitiator          byte
-	busOwnerShorthandPending   bool
-	busOwnerShorthandFirstByte byte
-	busDirty                   bool
-	busOwned                   time.Time
+	busToken                     chan struct{}
+	busOwner                     uint64
+	busOwnerInitiator            byte
+	busOwnerShorthandPending     bool
+	busOwnerShorthandExpectedLen int
+	busOwnerShorthandExpected    [2]byte
+	busOwnerShorthandObservedLen int
+	busOwnerShorthandObserved    [2]byte
+	busDirty                     bool
+	busOwned                     time.Time
 
 	pendingStartMu sync.Mutex
 	pendingStart   *pendingStart
@@ -1077,8 +1080,7 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 				server.upstreamFeatures.Store(uint32(frame.Payload[0]))
 			}
 			if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResReceived && len(frame.Payload) == 1 {
-				prefixFrame, prefixSkipOwner, prefixSkipPending, injectPrefix :=
-					server.observerPrefixFrameForWireSymbol(frame.Payload[0])
+				atTelegramStart := server.isAtTelegramStart()
 				server.lastWireRXAtNano.Store(time.Now().UTC().UnixNano())
 				if server.cfg.Debug {
 					log.Printf("wire_rx symbol=0x%02X", frame.Payload[0])
@@ -1098,13 +1100,7 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 					continue
 				}
 
-				if injectPrefix {
-					server.broadcastReceivedWithObserverPrefix(
-						prefixFrame,
-						prefixSkipOwner,
-						prefixSkipPending,
-						frame,
-					)
+				if server.handleObserverPrefixForReceived(frame, atTelegramStart) {
 					continue
 				}
 			}
@@ -1408,46 +1404,56 @@ func (server *Server) clearPendingInfo(sessionID uint64) {
 	server.pendingInfoMu.Unlock()
 }
 
-func (server *Server) observerPrefixFrameForWireSymbol(symbol byte) (downstream.Frame, uint64, uint64, bool) {
-	if symbol == ebusSyn {
-		return downstream.Frame{}, 0, 0, false
-	}
-
+func (server *Server) isAtTelegramStart() bool {
 	server.observedMu.Lock()
 	atTelegramStart := server.startOfTelegram
 	server.observedMu.Unlock()
-	if !atTelegramStart {
-		return downstream.Frame{}, 0, 0, false
+	return atTelegramStart
+}
+
+func (server *Server) handleObserverPrefixForReceived(frame downstream.Frame, atTelegramStart bool) bool {
+	if len(frame.Payload) != 1 {
+		return false
+	}
+	symbol := frame.Payload[0]
+	if symbol == ebusSyn {
+		server.clearOwnerShorthandState()
+		return false
 	}
 
-	server.mutex.Lock()
-	owner := server.busOwner
-	initiator := server.busOwnerInitiator
-	pending := server.busOwnerShorthandPending
-	expectedSymbol := server.busOwnerShorthandFirstByte
-	if pending {
-		server.busOwnerShorthandPending = false
-		server.busOwnerShorthandFirstByte = 0
+	owner, initiator, pending, expectedLen, observedLen := server.ownerShorthandState()
+	if owner == 0 || initiator == 0 || !pending || expectedLen < 2 {
+		return false
 	}
-	server.mutex.Unlock()
-	if owner == 0 || initiator == 0 {
-		return downstream.Frame{}, 0, 0, false
-	}
-	if !pending || symbol != expectedSymbol {
-		return downstream.Frame{}, 0, 0, false
+	if observedLen == 0 && !atTelegramStart {
+		return false
 	}
 
-	var pendingSessionID uint64
-	server.pendingStartMu.Lock()
-	if server.pendingStart != nil && server.pendingStart.mode == pendingStartModeUDPPlain {
-		pendingSessionID = server.pendingStart.sessionID
+	observerFrames, injectPrefix, holdOwnerOnly, matched := server.advanceOwnerShorthandProbe(symbol)
+	if !matched {
+		return false
 	}
-	server.pendingStartMu.Unlock()
 
-	return downstream.Frame{
-		Command: byte(southboundenh.ENHResReceived),
-		Payload: []byte{initiator},
-	}, owner, pendingSessionID, true
+	pendingSessionID := server.pendingUDPPlainStartSessionID()
+	server.broadcastReceivedToOwner(frame, owner)
+	if holdOwnerOnly {
+		return true
+	}
+	if injectPrefix {
+		server.broadcastReceivedFramesWithObserverPrefix(
+			downstream.Frame{
+				Command: byte(southboundenh.ENHResReceived),
+				Payload: []byte{initiator},
+			},
+			owner,
+			pendingSessionID,
+			observerFrames,
+		)
+		return true
+	}
+
+	server.broadcastReceivedFramesToObservers(observerFrames, owner, pendingSessionID)
+	return true
 }
 
 func (server *Server) broadcast(frame downstream.Frame) {
@@ -1482,6 +1488,73 @@ func (server *Server) broadcastReceivedWithObserverPrefix(
 		}
 		server.enqueueOrClose(sess, frame, "broadcast")
 	}
+}
+
+func (server *Server) broadcastReceivedFramesWithObserverPrefix(
+	prefix downstream.Frame,
+	skipOwnerID uint64,
+	skipPendingID uint64,
+	frames []downstream.Frame,
+) {
+	if len(frames) == 0 {
+		return
+	}
+
+	server.mutex.Lock()
+	sessions := make([]*session, 0, len(server.sessions))
+	for _, sess := range server.sessions {
+		sessions = append(sessions, sess)
+	}
+	server.mutex.Unlock()
+
+	for _, sess := range sessions {
+		if sess.id == skipOwnerID || sess.id == skipPendingID {
+			continue
+		}
+		server.enqueueOrClose(sess, prefix, "broadcast_observer_prefix")
+		for _, frame := range frames {
+			server.enqueueOrClose(sess, frame, "broadcast_observer_buffer")
+		}
+	}
+}
+
+func (server *Server) broadcastReceivedFramesToObservers(
+	frames []downstream.Frame,
+	skipOwnerID uint64,
+	skipPendingID uint64,
+) {
+	if len(frames) == 0 {
+		return
+	}
+
+	server.mutex.Lock()
+	sessions := make([]*session, 0, len(server.sessions))
+	for _, sess := range server.sessions {
+		sessions = append(sessions, sess)
+	}
+	server.mutex.Unlock()
+
+	for _, sess := range sessions {
+		if sess.id == skipOwnerID || sess.id == skipPendingID {
+			continue
+		}
+		for _, frame := range frames {
+			server.enqueueOrClose(sess, frame, "broadcast_observer_buffer")
+		}
+	}
+}
+
+func (server *Server) broadcastReceivedToOwner(frame downstream.Frame, ownerID uint64) {
+	if ownerID == 0 {
+		return
+	}
+	server.mutex.Lock()
+	sess := server.sessions[ownerID]
+	server.mutex.Unlock()
+	if sess == nil {
+		return
+	}
+	server.enqueueOrClose(sess, frame, "broadcast_owner_only")
 }
 
 func (server *Server) broadcastUDPPlainByte(value byte) {
@@ -1597,7 +1670,10 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 	server.busOwner = 0
 	server.busOwnerInitiator = 0
 	server.busOwnerShorthandPending = false
-	server.busOwnerShorthandFirstByte = 0
+	server.busOwnerShorthandExpectedLen = 0
+	server.busOwnerShorthandExpected = [2]byte{}
+	server.busOwnerShorthandObservedLen = 0
+	server.busOwnerShorthandObserved = [2]byte{}
 	server.busDirty = false
 	server.busOwned = time.Time{}
 	server.mutex.Unlock()
@@ -1610,7 +1686,10 @@ func (server *Server) setBusOwner(sessionID uint64, initiator byte) {
 	server.busOwner = sessionID
 	server.busOwnerInitiator = initiator
 	server.busOwnerShorthandPending = false
-	server.busOwnerShorthandFirstByte = 0
+	server.busOwnerShorthandExpectedLen = 0
+	server.busOwnerShorthandExpected = [2]byte{}
+	server.busOwnerShorthandObservedLen = 0
+	server.busOwnerShorthandObserved = [2]byte{}
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.mutex.Unlock()
@@ -1626,11 +1705,98 @@ func (server *Server) noteOwnerShorthandSend(sessionID uint64, firstByte byte) {
 
 	server.mutex.Lock()
 	defer server.mutex.Unlock()
-	if server.busOwner != sessionID || server.busOwnerShorthandPending {
+	if server.busOwner != sessionID {
+		return
+	}
+	if server.busOwnerShorthandExpectedLen >= len(server.busOwnerShorthandExpected) {
 		return
 	}
 	server.busOwnerShorthandPending = true
-	server.busOwnerShorthandFirstByte = firstByte
+	server.busOwnerShorthandExpected[server.busOwnerShorthandExpectedLen] = firstByte
+	server.busOwnerShorthandExpectedLen++
+}
+
+func (server *Server) clearOwnerShorthandState() {
+	server.mutex.Lock()
+	server.busOwnerShorthandPending = false
+	server.busOwnerShorthandExpectedLen = 0
+	server.busOwnerShorthandExpected = [2]byte{}
+	server.busOwnerShorthandObservedLen = 0
+	server.busOwnerShorthandObserved = [2]byte{}
+	server.mutex.Unlock()
+}
+
+func (server *Server) ownerShorthandState() (uint64, byte, bool, int, int) {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+	return server.busOwner, server.busOwnerInitiator, server.busOwnerShorthandPending, server.busOwnerShorthandExpectedLen, server.busOwnerShorthandObservedLen
+}
+
+func (server *Server) pendingUDPPlainStartSessionID() uint64 {
+	server.pendingStartMu.Lock()
+	defer server.pendingStartMu.Unlock()
+	if server.pendingStart != nil && server.pendingStart.mode == pendingStartModeUDPPlain {
+		return server.pendingStart.sessionID
+	}
+	return 0
+}
+
+func (server *Server) advanceOwnerShorthandProbe(symbol byte) ([]downstream.Frame, bool, bool, bool) {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+
+	if !server.busOwnerShorthandPending || server.busOwnerShorthandExpectedLen < 2 {
+		return nil, false, false, false
+	}
+	if server.busOwnerShorthandObservedLen >= len(server.busOwnerShorthandObserved) {
+		server.busOwnerShorthandPending = false
+		server.busOwnerShorthandExpectedLen = 0
+		server.busOwnerShorthandExpected = [2]byte{}
+		server.busOwnerShorthandObservedLen = 0
+		server.busOwnerShorthandObserved = [2]byte{}
+		return nil, false, false, false
+	}
+
+	index := server.busOwnerShorthandObservedLen
+	server.busOwnerShorthandObserved[index] = symbol
+	server.busOwnerShorthandObservedLen++
+
+	if symbol != server.busOwnerShorthandExpected[index] {
+		observedLen := server.busOwnerShorthandObservedLen
+		observedFrames := shorthandObservedFrames(server.busOwnerShorthandObserved[:observedLen])
+		server.busOwnerShorthandPending = false
+		server.busOwnerShorthandExpectedLen = 0
+		server.busOwnerShorthandExpected = [2]byte{}
+		server.busOwnerShorthandObservedLen = 0
+		server.busOwnerShorthandObserved = [2]byte{}
+		if index == 0 {
+			return nil, false, false, false
+		}
+		return observedFrames, false, false, true
+	}
+
+	if server.busOwnerShorthandObservedLen < 2 {
+		return nil, false, true, true
+	}
+
+	frames := shorthandObservedFrames(server.busOwnerShorthandObserved[:server.busOwnerShorthandObservedLen])
+	server.busOwnerShorthandPending = false
+	server.busOwnerShorthandExpectedLen = 0
+	server.busOwnerShorthandExpected = [2]byte{}
+	server.busOwnerShorthandObservedLen = 0
+	server.busOwnerShorthandObserved = [2]byte{}
+	return frames, true, false, true
+}
+
+func shorthandObservedFrames(symbols []byte) []downstream.Frame {
+	frames := make([]downstream.Frame, 0, len(symbols))
+	for _, symbol := range symbols {
+		frames = append(frames, downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		})
+	}
+	return frames
 }
 
 func (server *Server) releaseBusIfIdleSyn() {

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -73,11 +73,13 @@ type Server struct {
 	observedInitiatorAt map[byte]time.Time
 	collisionBySession  map[uint64]byte
 
-	busToken          chan struct{}
-	busOwner          uint64
-	busOwnerInitiator byte
-	busDirty          bool
-	busOwned          time.Time
+	busToken                   chan struct{}
+	busOwner                   uint64
+	busOwnerInitiator          byte
+	busOwnerShorthandPending   bool
+	busOwnerShorthandFirstByte byte
+	busDirty                   bool
+	busOwned                   time.Time
 
 	pendingStartMu sync.Mutex
 	pendingStart   *pendingStart
@@ -827,6 +829,7 @@ func (server *Server) handleSend(sessionID uint64, data byte) {
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.mutex.Unlock()
+	server.noteOwnerShorthandSend(sessionID, data)
 
 	sendFrame := downstream.Frame{
 		Command: byte(southboundenh.ENHReqSend),
@@ -1420,11 +1423,17 @@ func (server *Server) observerPrefixFrameForWireSymbol(symbol byte) (downstream.
 	server.mutex.Lock()
 	owner := server.busOwner
 	initiator := server.busOwnerInitiator
+	pending := server.busOwnerShorthandPending
+	expectedSymbol := server.busOwnerShorthandFirstByte
+	if pending {
+		server.busOwnerShorthandPending = false
+		server.busOwnerShorthandFirstByte = 0
+	}
 	server.mutex.Unlock()
 	if owner == 0 || initiator == 0 {
 		return downstream.Frame{}, 0, 0, false
 	}
-	if symbol == initiator {
+	if !pending || symbol != expectedSymbol {
 		return downstream.Frame{}, 0, 0, false
 	}
 
@@ -1587,6 +1596,8 @@ func (server *Server) releaseBusIfOwner(sessionID uint64) {
 	}
 	server.busOwner = 0
 	server.busOwnerInitiator = 0
+	server.busOwnerShorthandPending = false
+	server.busOwnerShorthandFirstByte = 0
 	server.busDirty = false
 	server.busOwned = time.Time{}
 	server.mutex.Unlock()
@@ -1598,9 +1609,28 @@ func (server *Server) setBusOwner(sessionID uint64, initiator byte) {
 	server.mutex.Lock()
 	server.busOwner = sessionID
 	server.busOwnerInitiator = initiator
+	server.busOwnerShorthandPending = false
+	server.busOwnerShorthandFirstByte = 0
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.mutex.Unlock()
+}
+
+func (server *Server) noteOwnerShorthandSend(sessionID uint64, firstByte byte) {
+	server.observedMu.Lock()
+	atTelegramStart := server.startOfTelegram
+	server.observedMu.Unlock()
+	if !atTelegramStart {
+		return
+	}
+
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+	if server.busOwner != sessionID || server.busOwnerShorthandPending {
+		return
+	}
+	server.busOwnerShorthandPending = true
+	server.busOwnerShorthandFirstByte = firstByte
 }
 
 func (server *Server) releaseBusIfIdleSyn() {

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -191,3 +191,115 @@ func TestRunUpstreamReaderBroadcastsReceivedWhileStartPendingENH(t *testing.T) {
 	_ = upstream.Close()
 	server.waitGroup.Wait()
 }
+
+func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffic(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                 Config{UpstreamTransport: UpstreamENH},
+		upstream:            upstream,
+		sessions:            map[uint64]*session{},
+		synCh:               make(chan struct{}, 1),
+		startOfTelegram:     true,
+		observedInitiatorAt: make(map[byte]time.Time),
+		busOwner:            1,
+		busOwnerInitiator:   0xF7,
+		busDirty:            true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	wireSymbols := []byte{
+		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
+		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
+		0xAA,
+	}
+	for _, symbol := range wireSymbols {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+
+	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	if !equalBytes(observerSymbols, wantObserver) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
+	}
+	if !containsGatewayStyleTransaction(observerSymbols, 0xF7, 0x15, 0xB5, 0x24) {
+		t.Fatalf("observer symbols = % X; want reconstructible gateway-style transaction", observerSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func readReceivedSymbols(t *testing.T, sessionState *session, count int) []byte {
+	t.Helper()
+
+	symbols := make([]byte, 0, count)
+	for len(symbols) < count {
+		select {
+		case frame := <-sessionState.sendCh:
+			if southboundenh.ENHCommand(frame.Command) != southboundenh.ENHResReceived {
+				t.Fatalf("command = 0x%02X; want ENHResReceived", frame.Command)
+			}
+			if len(frame.Payload) != 1 {
+				t.Fatalf("payload len = %d; want 1", len(frame.Payload))
+			}
+			symbols = append(symbols, frame.Payload[0])
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timed out waiting for %d received symbols; got %d", count, len(symbols))
+		}
+	}
+
+	return symbols
+}
+
+func equalBytes(left []byte, right []byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsGatewayStyleTransaction(symbols []byte, initiator byte, target byte, primary byte, secondary byte) bool {
+	if len(symbols) < 5 {
+		return false
+	}
+
+	for index := 0; index <= len(symbols)-5; index++ {
+		if symbols[index] != initiator ||
+			symbols[index+1] != target ||
+			symbols[index+2] != primary ||
+			symbols[index+3] != secondary {
+			continue
+		}
+		for tail := index + 4; tail < len(symbols); tail++ {
+			if symbols[tail] == ebusSyn {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -225,7 +225,16 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
 		0xAA,
 	}
-	for _, symbol := range wireSymbols {
+	for _, symbol := range wireSymbols[:2] {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
+
+	for _, symbol := range wireSymbols[2:] {
 		upstream.readCh <- downstream.Frame{
 			Command: byte(southboundenh.ENHResReceived),
 			Payload: []byte{symbol},
@@ -245,6 +254,67 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 	}
 	if !containsGatewayStyleTransaction(observerSymbols, 0xF7, 0x15, 0xB5, 0x24) {
 		t.Fatalf("observer symbols = % X; want reconstructible gateway-style transaction", observerSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestRunUpstreamReaderFlushesBufferedObserverRequestOnTerminalSyn(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x15},
+	}
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0xB5},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{ebusSyn},
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], 3)
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], 4)
+
+	if !equalBytes(activeSymbols, []byte{0x15, 0xB5, ebusSyn}) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, []byte{0x15, 0xB5, ebusSyn})
+	}
+
+	wantObserver := []byte{0xF7, 0x15, 0xB5, ebusSyn}
+	if !equalBytes(observerSymbols, wantObserver) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
 	}
 
 	cancel()
@@ -295,14 +365,22 @@ func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testin
 		}
 	}
 
+	assertNoReceivedFrames(t, server.sessions[2])
+
 	server.handleSend(1, 0xB5)
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0xB5},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
 
 	wireSymbols = append(wireSymbols,
 		0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
 		0xAA,
 	)
-	for _, symbol := range wireSymbols[1:] {
+	for _, symbol := range wireSymbols[2:] {
 		upstream.readCh <- downstream.Frame{
 			Command: byte(southboundenh.ENHResReceived),
 			Payload: []byte{symbol},
@@ -522,14 +600,22 @@ func TestRunUpstreamReaderPreservesObserverContextWhenFirstRXPrecedesSecondSend(
 		Payload: []byte{0x15},
 	}
 
+	assertNoReceivedFrames(t, server.sessions[2])
+
 	server.handleSend(1, 0xB5)
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0xB5},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
 
 	wireSymbols := []byte{
 		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
 		0xAA,
 	}
-	for _, symbol := range wireSymbols[1:] {
+	for _, symbol := range wireSymbols[2:] {
 		upstream.readCh <- downstream.Frame{
 			Command: byte(southboundenh.ENHResReceived),
 			Payload: []byte{symbol},
@@ -573,6 +659,16 @@ func readReceivedSymbols(t *testing.T, sessionState *session, count int) []byte 
 	}
 
 	return symbols
+}
+
+func assertNoReceivedFrames(t *testing.T, sessionState *session) {
+	t.Helper()
+
+	select {
+	case frame := <-sessionState.sendCh:
+		t.Fatalf("unexpected frame while observer replay should still be buffered: cmd=0x%02X payload=% X", frame.Command, frame.Payload)
+	case <-time.After(75 * time.Millisecond):
+	}
 }
 
 func equalBytes(left []byte, right []byte) bool {

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -197,15 +197,16 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 
 	upstream := newFakeUpstream()
 	server := &Server{
-		cfg:                 Config{UpstreamTransport: UpstreamENH},
-		upstream:            upstream,
-		sessions:            map[uint64]*session{},
-		synCh:               make(chan struct{}, 1),
-		startOfTelegram:     true,
-		observedInitiatorAt: make(map[byte]time.Time),
-		busOwner:            1,
-		busOwnerInitiator:   0xF7,
-		busDirty:            true,
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
 	}
 	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
 	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
@@ -256,15 +257,16 @@ func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testin
 
 	upstream := newFakeUpstream()
 	server := &Server{
-		cfg:                 Config{UpstreamTransport: UpstreamENH},
-		upstream:            upstream,
-		sessions:            map[uint64]*session{},
-		synCh:               make(chan struct{}, 1),
-		startOfTelegram:     true,
-		observedInitiatorAt: make(map[byte]time.Time),
-		busOwner:            1,
-		busOwnerInitiator:   0xF7,
-		busDirty:            true,
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
 		pendingStart: &pendingStart{
 			sessionID: 2,
 			respCh:    make(chan downstream.Frame, 1),
@@ -282,14 +284,25 @@ func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testin
 	go server.runUpstreamReader(ctx)
 
 	server.handleSend(1, 0x15)
-	server.handleSend(1, 0xB5)
 
 	wireSymbols := []byte{
-		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
-		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
-		0xAA,
+		0x15,
 	}
 	for _, symbol := range wireSymbols {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	server.handleSend(1, 0xB5)
+
+	wireSymbols = append(wireSymbols,
+		0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
+		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
+		0xAA,
+	)
+	for _, symbol := range wireSymbols[1:] {
 		upstream.readCh <- downstream.Frame{
 			Command: byte(southboundenh.ENHResReceived),
 			Payload: []byte{symbol},
@@ -321,15 +334,16 @@ func TestRunUpstreamReaderPrefixesShorthandTargetThatLooksLikeInitiator(t *testi
 
 	upstream := newFakeUpstream()
 	server := &Server{
-		cfg:                 Config{UpstreamTransport: UpstreamENH},
-		upstream:            upstream,
-		sessions:            map[uint64]*session{},
-		synCh:               make(chan struct{}, 1),
-		startOfTelegram:     true,
-		observedInitiatorAt: make(map[byte]time.Time),
-		busOwner:            1,
-		busOwnerInitiator:   0xF7,
-		busDirty:            true,
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
 	}
 	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
 	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
@@ -399,9 +413,6 @@ func TestRunUpstreamReaderDoesNotPrefixFullForeignTelegramAtBoundary(t *testing.
 	server.waitGroup.Add(1)
 	go server.runUpstreamReader(ctx)
 
-	server.handleSend(1, 0x15)
-	server.handleSend(1, 0xB5)
-
 	wireSymbols := []byte{
 		0x31, 0x08, 0xB5, 0x24, 0x02, 0x15, 0x10, 0x00,
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
@@ -453,9 +464,6 @@ func TestRunUpstreamReaderDoesNotPrefixForeignTelegramWhenFirstByteMatchesOwnerS
 	server.waitGroup.Add(1)
 	go server.runUpstreamReader(ctx)
 
-	server.handleSend(1, 0x31)
-	server.handleSend(1, 0xB5)
-
 	wireSymbols := []byte{
 		0x31, 0x08, 0xB5, 0x24, 0x02, 0x15, 0x10, 0x00,
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
@@ -476,6 +484,68 @@ func TestRunUpstreamReaderDoesNotPrefixForeignTelegramWhenFirstByteMatchesOwnerS
 	}
 	if !equalBytes(observerSymbols, wireSymbols) {
 		t.Fatalf("observer symbols = % X; want % X (no synthetic prefix on overlapping foreign telegram)", observerSymbols, wireSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestRunUpstreamReaderPreservesObserverContextWhenFirstRXPrecedesSecondSend(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		busDirty:             true,
+		ownerObserverAtStart: true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x15},
+	}
+
+	server.handleSend(1, 0xB5)
+
+	wireSymbols := []byte{
+		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
+		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
+		0xAA,
+	}
+	for _, symbol := range wireSymbols[1:] {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+
+	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	if !equalBytes(observerSymbols, wantObserver) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
 	}
 
 	cancel()

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -217,6 +217,7 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 	go server.runUpstreamReader(ctx)
 
 	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
 
 	wireSymbols := []byte{
 		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
@@ -281,6 +282,7 @@ func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testin
 	go server.runUpstreamReader(ctx)
 
 	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
 
 	wireSymbols := []byte{
 		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
@@ -339,6 +341,7 @@ func TestRunUpstreamReaderPrefixesShorthandTargetThatLooksLikeInitiator(t *testi
 	go server.runUpstreamReader(ctx)
 
 	server.handleSend(1, 0x31)
+	server.handleSend(1, 0xB5)
 
 	wireSymbols := []byte{
 		0x31, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
@@ -397,6 +400,7 @@ func TestRunUpstreamReaderDoesNotPrefixFullForeignTelegramAtBoundary(t *testing.
 	go server.runUpstreamReader(ctx)
 
 	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
 
 	wireSymbols := []byte{
 		0x31, 0x08, 0xB5, 0x24, 0x02, 0x15, 0x10, 0x00,
@@ -418,6 +422,60 @@ func TestRunUpstreamReaderDoesNotPrefixFullForeignTelegramAtBoundary(t *testing.
 	}
 	if !equalBytes(observerSymbols, wireSymbols) {
 		t.Fatalf("observer symbols = % X; want % X (no synthetic prefix on foreign full telegram)", observerSymbols, wireSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestRunUpstreamReaderDoesNotPrefixForeignTelegramWhenFirstByteMatchesOwnerShorthand(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                 Config{UpstreamTransport: UpstreamENH},
+		upstream:            upstream,
+		sessions:            map[uint64]*session{},
+		synCh:               make(chan struct{}, 1),
+		startOfTelegram:     true,
+		observedInitiatorAt: make(map[byte]time.Time),
+		busOwner:            1,
+		busOwnerInitiator:   0xF7,
+		busDirty:            true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x31)
+	server.handleSend(1, 0xB5)
+
+	wireSymbols := []byte{
+		0x31, 0x08, 0xB5, 0x24, 0x02, 0x15, 0x10, 0x00,
+		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
+		0xAA,
+	}
+	for _, symbol := range wireSymbols {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols))
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+	if !equalBytes(observerSymbols, wireSymbols) {
+		t.Fatalf("observer symbols = % X; want % X (no synthetic prefix on overlapping foreign telegram)", observerSymbols, wireSymbols)
 	}
 
 	cancel()

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -203,6 +203,7 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 		synCh:                make(chan struct{}, 1),
 		startOfTelegram:      true,
 		observedInitiatorAt:  make(map[byte]time.Time),
+		collisionBySession:   make(map[uint64]byte),
 		busOwner:             1,
 		busOwnerInitiator:    0xF7,
 		ownerObserverAtStart: true,
@@ -272,6 +273,7 @@ func TestRunUpstreamReaderFlushesBufferedObserverRequestOnTerminalSyn(t *testing
 		synCh:                make(chan struct{}, 1),
 		startOfTelegram:      true,
 		observedInitiatorAt:  make(map[byte]time.Time),
+		collisionBySession:   make(map[uint64]byte),
 		busOwner:             1,
 		busOwnerInitiator:    0xF7,
 		ownerObserverAtStart: true,
@@ -333,6 +335,7 @@ func TestRunUpstreamReaderDoesNotReplayUnconfirmedOwnerBytesOnTerminalSyn(t *tes
 		synCh:                make(chan struct{}, 1),
 		startOfTelegram:      true,
 		observedInitiatorAt:  make(map[byte]time.Time),
+		collisionBySession:   make(map[uint64]byte),
 		busOwner:             1,
 		busOwnerInitiator:    0xF7,
 		ownerObserverAtStart: true,
@@ -372,6 +375,70 @@ func TestRunUpstreamReaderDoesNotReplayUnconfirmedOwnerBytesOnTerminalSyn(t *tes
 	wantObserver := []byte{0xF7, 0x15, ebusSyn}
 	if !equalBytes(observerSymbols, wantObserver) {
 		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestRunUpstreamReaderAbortBeforeSynPreservesProvenWireBytesToObservers(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		collisionBySession:   make(map[uint64]byte),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x15},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResErrorEBUS),
+		Payload: []byte{0x31},
+	}
+
+	ownerSymbols := readReceivedSymbols(t, server.sessions[1], 1)
+	if !equalBytes(ownerSymbols, []byte{0x15}) {
+		t.Fatalf("owner symbols = % X; want % X", ownerSymbols, []byte{0x15})
+	}
+
+	ownerFrame := readFrame(t, server.sessions[1])
+	if southboundenh.ENHCommand(ownerFrame.Command) != southboundenh.ENHResErrorEBUS {
+		t.Fatalf("owner command = 0x%02X; want ENHResErrorEBUS", ownerFrame.Command)
+	}
+	if !equalBytes(ownerFrame.Payload, []byte{0x31}) {
+		t.Fatalf("owner payload = % X; want 31", ownerFrame.Payload)
+	}
+
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], 1)
+	if !equalBytes(observerSymbols, []byte{0x15}) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, []byte{0x15})
 	}
 
 	cancel()
@@ -825,6 +892,18 @@ func readReceivedSymbols(t *testing.T, sessionState *session, count int) []byte 
 	}
 
 	return symbols
+}
+
+func readFrame(t *testing.T, sessionState *session) downstream.Frame {
+	t.Helper()
+
+	select {
+	case frame := <-sessionState.sendCh:
+		return frame
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for frame")
+		return downstream.Frame{}
+	}
 }
 
 func assertNoReceivedFrames(t *testing.T, sessionState *session) {

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -446,6 +446,56 @@ func TestRunUpstreamReaderAbortBeforeSynPreservesProvenWireBytesToObservers(t *t
 	server.waitGroup.Wait()
 }
 
+func TestRunUpstreamReaderEOFBeforeSynPreservesProvenWireBytesToObservers(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		collisionBySession:   make(map[uint64]byte),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x15},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
+
+	ownerSymbols := readReceivedSymbols(t, server.sessions[1], 1)
+	if !equalBytes(ownerSymbols, []byte{0x15}) {
+		t.Fatalf("owner symbols = % X; want % X", ownerSymbols, []byte{0x15})
+	}
+
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], 1)
+	if !equalBytes(observerSymbols, []byte{0x15}) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, []byte{0x15})
+	}
+}
+
 func TestRunUpstreamReaderDoesNotSuppressForeignInterleavingByteDuringReplaySuppression(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -243,18 +243,15 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 	}
 
 	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
-	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+2)
 
 	if !equalBytes(activeSymbols, wireSymbols) {
 		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
 	}
 
-	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	wantObserver := append([]byte{0xF7, 0x15, 0xB5, ebusSyn}, wireSymbols[2:]...)
 	if !equalBytes(observerSymbols, wantObserver) {
 		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
-	}
-	if !containsGatewayStyleTransaction(observerSymbols, 0xF7, 0x15, 0xB5, 0x24) {
-		t.Fatalf("observer symbols = % X; want reconstructible gateway-style transaction", observerSymbols)
 	}
 
 	cancel()
@@ -719,18 +716,15 @@ func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testin
 	}
 
 	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
-	pendingObserverSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+	pendingObserverSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+2)
 
 	if !equalBytes(activeSymbols, wireSymbols) {
 		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
 	}
 
-	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	wantObserver := append([]byte{0xF7, 0x15, 0xB5, ebusSyn}, wireSymbols[2:]...)
 	if !equalBytes(pendingObserverSymbols, wantObserver) {
 		t.Fatalf("pending observer symbols = % X; want % X", pendingObserverSymbols, wantObserver)
-	}
-	if !containsGatewayStyleTransaction(pendingObserverSymbols, 0xF7, 0x15, 0xB5, 0x24) {
-		t.Fatalf("pending observer symbols = % X; want reconstructible gateway-style transaction", pendingObserverSymbols)
 	}
 
 	cancel()
@@ -779,18 +773,15 @@ func TestRunUpstreamReaderPrefixesShorthandTargetThatLooksLikeInitiator(t *testi
 	}
 
 	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
-	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+2)
 
 	if !equalBytes(activeSymbols, wireSymbols) {
 		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
 	}
 
-	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	wantObserver := append([]byte{0xF7, 0x31, 0xB5, ebusSyn}, wireSymbols[2:]...)
 	if !equalBytes(observerSymbols, wantObserver) {
 		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
-	}
-	if !containsGatewayStyleTransaction(observerSymbols, 0xF7, 0x31, 0xB5, 0x24) {
-		t.Fatalf("observer symbols = % X; want reconstructible overlapped-target transaction", observerSymbols)
 	}
 
 	cancel()
@@ -954,13 +945,13 @@ func TestRunUpstreamReaderPreservesObserverContextWhenFirstRXPrecedesSecondSend(
 	}
 
 	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
-	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+2)
 
 	if !equalBytes(activeSymbols, wireSymbols) {
 		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
 	}
 
-	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	wantObserver := append([]byte{0xF7, 0x15, 0xB5, ebusSyn}, wireSymbols[2:]...)
 	if !equalBytes(observerSymbols, wantObserver) {
 		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
 	}

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -216,6 +216,8 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 	server.waitGroup.Add(1)
 	go server.runUpstreamReader(ctx)
 
+	server.handleSend(1, 0x15)
+
 	wireSymbols := []byte{
 		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
@@ -278,6 +280,8 @@ func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testin
 	server.waitGroup.Add(1)
 	go server.runUpstreamReader(ctx)
 
+	server.handleSend(1, 0x15)
+
 	wireSymbols := []byte{
 		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
@@ -334,6 +338,8 @@ func TestRunUpstreamReaderPrefixesShorthandTargetThatLooksLikeInitiator(t *testi
 	server.waitGroup.Add(1)
 	go server.runUpstreamReader(ctx)
 
+	server.handleSend(1, 0x31)
+
 	wireSymbols := []byte{
 		0x31, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
 		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
@@ -359,6 +365,59 @@ func TestRunUpstreamReaderPrefixesShorthandTargetThatLooksLikeInitiator(t *testi
 	}
 	if !containsGatewayStyleTransaction(observerSymbols, 0xF7, 0x31, 0xB5, 0x24) {
 		t.Fatalf("observer symbols = % X; want reconstructible overlapped-target transaction", observerSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestRunUpstreamReaderDoesNotPrefixFullForeignTelegramAtBoundary(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                 Config{UpstreamTransport: UpstreamENH},
+		upstream:            upstream,
+		sessions:            map[uint64]*session{},
+		synCh:               make(chan struct{}, 1),
+		startOfTelegram:     true,
+		observedInitiatorAt: make(map[byte]time.Time),
+		busOwner:            1,
+		busOwnerInitiator:   0xF7,
+		busDirty:            true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+
+	wireSymbols := []byte{
+		0x31, 0x08, 0xB5, 0x24, 0x02, 0x15, 0x10, 0x00,
+		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
+		0xAA,
+	}
+	for _, symbol := range wireSymbols {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols))
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+	if !equalBytes(observerSymbols, wireSymbols) {
+		t.Fatalf("observer symbols = % X; want % X (no synthetic prefix on foreign full telegram)", observerSymbols, wireSymbols)
 	}
 
 	cancel()

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -322,6 +322,63 @@ func TestRunUpstreamReaderFlushesBufferedObserverRequestOnTerminalSyn(t *testing
 	server.waitGroup.Wait()
 }
 
+func TestRunUpstreamReaderDoesNotReplayUnconfirmedOwnerBytesOnTerminalSyn(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x15},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{ebusSyn},
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], 2)
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], 3)
+
+	if !equalBytes(activeSymbols, []byte{0x15, ebusSyn}) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, []byte{0x15, ebusSyn})
+	}
+
+	wantObserver := []byte{0xF7, 0x15, ebusSyn}
+	if !equalBytes(observerSymbols, wantObserver) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
 func TestRunUpstreamReaderDoesNotSuppressForeignInterleavingByteDuringReplaySuppression(t *testing.T) {
 	t.Parallel()
 
@@ -366,6 +423,64 @@ func TestRunUpstreamReaderDoesNotSuppressForeignInterleavingByteDuringReplaySupp
 	}
 	if !equalBytes(observerSymbols, wireSymbols) {
 		t.Fatalf("observer symbols = % X; want % X (foreign interleaving must pass raw and abort replay)", observerSymbols, wireSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestRunUpstreamReaderReplaysSuppressedWireBytesRawWhenLaterByteMismatches(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
+
+	wireSymbols := []byte{0x15, 0x31, ebusSyn}
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{wireSymbols[0]},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
+
+	for _, symbol := range wireSymbols[1:] {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols))
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+	if !equalBytes(observerSymbols, wireSymbols) {
+		t.Fatalf("observer symbols = % X; want % X (suppressed proven wire bytes must be restored raw on later mismatch)", observerSymbols, wireSymbols)
 	}
 
 	cancel()

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -248,6 +248,68 @@ func TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffi
 	server.waitGroup.Wait()
 }
 
+func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                 Config{UpstreamTransport: UpstreamENH},
+		upstream:            upstream,
+		sessions:            map[uint64]*session{},
+		synCh:               make(chan struct{}, 1),
+		startOfTelegram:     true,
+		observedInitiatorAt: make(map[byte]time.Time),
+		busOwner:            1,
+		busOwnerInitiator:   0xF7,
+		busDirty:            true,
+		pendingStart: &pendingStart{
+			sessionID: 2,
+			respCh:    make(chan downstream.Frame, 1),
+			mode:      pendingStartModeENH,
+			initiator: 0x31,
+		},
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	wireSymbols := []byte{
+		0x15, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
+		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
+		0xAA,
+	}
+	for _, symbol := range wireSymbols {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	pendingObserverSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+
+	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	if !equalBytes(pendingObserverSymbols, wantObserver) {
+		t.Fatalf("pending observer symbols = % X; want % X", pendingObserverSymbols, wantObserver)
+	}
+	if !containsGatewayStyleTransaction(pendingObserverSymbols, 0xF7, 0x15, 0xB5, 0x24) {
+		t.Fatalf("pending observer symbols = % X; want reconstructible gateway-style transaction", pendingObserverSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
 func readReceivedSymbols(t *testing.T, sessionState *session, count int) []byte {
 	t.Helper()
 

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -496,6 +496,54 @@ func TestRunUpstreamReaderEOFBeforeSynPreservesProvenWireBytesToObservers(t *tes
 	}
 }
 
+func TestUnregisterSessionPreservesProvenWireBytesToObservers(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		collisionBySession:   make(map[uint64]byte),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
+
+	upstream.readCh <- downstream.Frame{
+		Command: byte(southboundenh.ENHResReceived),
+		Payload: []byte{0x15},
+	}
+
+	assertNoReceivedFrames(t, server.sessions[2])
+
+	server.unregisterSession(1)
+
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], 1)
+	if !equalBytes(observerSymbols, []byte{0x15}) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, []byte{0x15})
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
 func TestRunUpstreamReaderDoesNotSuppressForeignInterleavingByteDuringReplaySuppression(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -310,6 +310,62 @@ func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testin
 	server.waitGroup.Wait()
 }
 
+func TestRunUpstreamReaderPrefixesShorthandTargetThatLooksLikeInitiator(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                 Config{UpstreamTransport: UpstreamENH},
+		upstream:            upstream,
+		sessions:            map[uint64]*session{},
+		synCh:               make(chan struct{}, 1),
+		startOfTelegram:     true,
+		observedInitiatorAt: make(map[byte]time.Time),
+		busOwner:            1,
+		busOwnerInitiator:   0xF7,
+		busDirty:            true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	wireSymbols := []byte{
+		0x31, 0xB5, 0x24, 0x02, 0x08, 0x10, 0x00,
+		0x00, 0x03, 0x01, 0x42, 0x99, 0x00,
+		0xAA,
+	}
+	for _, symbol := range wireSymbols {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols)+1)
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+
+	wantObserver := append([]byte{0xF7}, wireSymbols...)
+	if !equalBytes(observerSymbols, wantObserver) {
+		t.Fatalf("observer symbols = % X; want % X", observerSymbols, wantObserver)
+	}
+	if !containsGatewayStyleTransaction(observerSymbols, 0xF7, 0x31, 0xB5, 0x24) {
+		t.Fatalf("observer symbols = % X; want reconstructible overlapped-target transaction", observerSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
 func readReceivedSymbols(t *testing.T, sessionState *session, count int) []byte {
 	t.Helper()
 

--- a/internal/adapterproxy/server_broadcast_test.go
+++ b/internal/adapterproxy/server_broadcast_test.go
@@ -322,6 +322,57 @@ func TestRunUpstreamReaderFlushesBufferedObserverRequestOnTerminalSyn(t *testing
 	server.waitGroup.Wait()
 }
 
+func TestRunUpstreamReaderDoesNotSuppressForeignInterleavingByteDuringReplaySuppression(t *testing.T) {
+	t.Parallel()
+
+	upstream := newFakeUpstream()
+	server := &Server{
+		cfg:                  Config{UpstreamTransport: UpstreamENH},
+		upstream:             upstream,
+		sessions:             map[uint64]*session{},
+		synCh:                make(chan struct{}, 1),
+		startOfTelegram:      true,
+		observedInitiatorAt:  make(map[byte]time.Time),
+		busOwner:             1,
+		busOwnerInitiator:    0xF7,
+		ownerObserverAtStart: true,
+		busDirty:             true,
+	}
+	server.sessions[1] = &session{id: 1, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+	server.sessions[2] = &session{id: 2, sendCh: make(chan downstream.Frame, 32), done: make(chan struct{})}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	server.handleSend(1, 0x15)
+	server.handleSend(1, 0xB5)
+
+	wireSymbols := []byte{0x31, 0x15, 0xB5, ebusSyn}
+	for _, symbol := range wireSymbols {
+		upstream.readCh <- downstream.Frame{
+			Command: byte(southboundenh.ENHResReceived),
+			Payload: []byte{symbol},
+		}
+	}
+
+	activeSymbols := readReceivedSymbols(t, server.sessions[1], len(wireSymbols))
+	observerSymbols := readReceivedSymbols(t, server.sessions[2], len(wireSymbols))
+
+	if !equalBytes(activeSymbols, wireSymbols) {
+		t.Fatalf("active symbols = % X; want % X", activeSymbols, wireSymbols)
+	}
+	if !equalBytes(observerSymbols, wireSymbols) {
+		t.Fatalf("observer symbols = % X; want % X (foreign interleaving must pass raw and abort replay)", observerSymbols, wireSymbols)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
 func TestRunUpstreamReaderPreservesObserverContextForPendingENHSession(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
Preserve reconstructible telegram context for northbound ENS observer sessions by injecting the active owner initiator at telegram start for observer fanout only.

## Why
Proxy-single coexistence currently mirrors shorthand active traffic upstream, but observer sessions miss the initiator/source byte that START selected for the active owner. That leaves the gateway passive reconstructor without enough context to parse real transactions from another session's traffic.

## Acceptance Criteria
- [x] An observer/northbound ENS session receives a reconstructible telegram stream for another session's active traffic, with enough initiator/boundary context for the gateway passive reconstructor to parse real transactions.
- [x] The active client contract remains unchanged: `START` still chooses the initiator and active clients still send shorthand bytes.
- [x] A 2-session regression covers one active session `START`ing `0xF7` and sending B524-shaped request/response traffic while an observer session receives a stream that replays into at least one gateway-style transaction.
- [x] Local CI is green.

## Validation
- `GOWORK=off go test ./internal/adapterproxy -run '^(TestRunUpstreamReaderBroadcastsReceivedToAllSessions|TestRunUpstreamReaderSuppressesReceivedWhileStartPending|TestRunUpstreamReaderBroadcastsReceivedWhileStartPendingENH|TestRunUpstreamReaderPreservesReconstructibleObserverContextForActiveTraffic)$' -count=1`
- `GOWORK=off go test ./internal/adapterproxy -count=1`
- `TRANSPORT_GATE_OWNER_OVERRIDE=OVERRIDE_TRANSPORT_GATE_BY_OWNER TRANSPORT_GATE_OWNER_REASON='proxy issue #80 local CI evidence for northbound ENS observer context preservation; no fresh transport matrix artifact in this pre-proof slice' ./scripts/ci_local.sh`

## Links
- Closes #80
- Doc-gate: YES (northbound observer transport/runtime behavior)
