### PR TITLE
Add INFO identity cache with RESETTED invalidation

### DIFF
--- a/internal/adapterproxy/adapter_info_cache.go
+++ b/internal/adapterproxy/adapter_info_cache.go
@@ -1,0 +1,79 @@
+package adapterproxy
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+// adapterInfoCache provides identity caching for INFO IDs 0x00, 0x01, 0x02.
+// Telemetry IDs (0x03–0x07) are always forwarded upstream.
+type adapterInfoCache struct {
+	mu      sync.Mutex
+	entries map[byte]*infoCacheEntry
+}
+
+type infoCacheEntry struct {
+	frames    []downstream.Frame // complete response frame sequence (length + data frames)
+	updatedAt time.Time
+}
+
+func newAdapterInfoCache() *adapterInfoCache {
+	return &adapterInfoCache{
+		entries: make(map[byte]*infoCacheEntry),
+	}
+}
+
+// isIdentityID returns true for INFO IDs that should be cached (static per session).
+func isIdentityID(infoID byte) bool {
+	return infoID <= 0x02 // 0x00=Version, 0x01=HW ID, 0x02=HW Config
+}
+
+// get returns cached frames for an identity INFO ID, or nil if not cached.
+func (c *adapterInfoCache) get(infoID byte) []downstream.Frame {
+	if !isIdentityID(infoID) {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[infoID]
+	if !ok {
+		return nil
+	}
+	// Return a copy to avoid mutation.
+	frames := make([]downstream.Frame, len(entry.frames))
+	for i, f := range entry.frames {
+		payload := make([]byte, len(f.Payload))
+		copy(payload, f.Payload)
+		frames[i] = downstream.Frame{Command: f.Command, Payload: payload}
+	}
+	return frames
+}
+
+// put stores the complete frame sequence for an identity INFO ID.
+func (c *adapterInfoCache) put(infoID byte, frames []downstream.Frame) {
+	if !isIdentityID(infoID) {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Deep copy frames for storage.
+	stored := make([]downstream.Frame, len(frames))
+	for i, f := range frames {
+		payload := make([]byte, len(f.Payload))
+		copy(payload, f.Payload)
+		stored[i] = downstream.Frame{Command: f.Command, Payload: payload}
+	}
+	c.entries[infoID] = &infoCacheEntry{
+		frames:    stored,
+		updatedAt: time.Now(),
+	}
+}
+
+// invalidateAll clears all cached identity entries (called on RESETTED).
+func (c *adapterInfoCache) invalidateAll() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = make(map[byte]*infoCacheEntry)
+}

--- a/internal/adapterproxy/adapter_info_cache_test.go
+++ b/internal/adapterproxy/adapter_info_cache_test.go
@@ -1,0 +1,138 @@
+package adapterproxy
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+func TestIsIdentityID(t *testing.T) {
+	tests := []struct {
+		id   byte
+		want bool
+	}{
+		{0x00, true},  // Version
+		{0x01, true},  // HW ID
+		{0x02, true},  // HW Config
+		{0x03, false}, // Temperature (telemetry)
+		{0x04, false}, // Supply voltage
+		{0x05, false}, // Bus voltage
+		{0x06, false}, // Reset info
+		{0x07, false}, // WiFi RSSI
+	}
+	for _, tt := range tests {
+		if got := isIdentityID(tt.id); got != tt.want {
+			t.Errorf("isIdentityID(0x%02x) = %v; want %v", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestCacheGetMiss(t *testing.T) {
+	c := newAdapterInfoCache()
+	if frames := c.get(0x00); frames != nil {
+		t.Errorf("expected nil for cold cache, got %v", frames)
+	}
+}
+
+func TestCachePutAndGet(t *testing.T) {
+	c := newAdapterInfoCache()
+	infoCmd := byte(0x0A) // ENHResInfo
+	frames := []downstream.Frame{
+		{Command: infoCmd, Payload: []byte{0x02}}, // length=2
+		{Command: infoCmd, Payload: []byte{0x23}}, // version
+		{Command: infoCmd, Payload: []byte{0x01}}, // features
+	}
+	c.put(0x00, frames)
+
+	got := c.get(0x00)
+	if got == nil {
+		t.Fatal("expected cached frames, got nil")
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 frames, got %d", len(got))
+	}
+	if got[1].Payload[0] != 0x23 {
+		t.Errorf("version byte = 0x%02x; want 0x23", got[1].Payload[0])
+	}
+}
+
+func TestCacheDeepCopy(t *testing.T) {
+	c := newAdapterInfoCache()
+	original := []downstream.Frame{
+		{Command: 0x0A, Payload: []byte{0x01}},
+		{Command: 0x0A, Payload: []byte{0xFF}},
+	}
+	c.put(0x00, original)
+
+	// Mutate original — should not affect cache.
+	original[1].Payload[0] = 0x00
+
+	got := c.get(0x00)
+	if got[1].Payload[0] != 0xFF {
+		t.Errorf("cache was mutated via original slice; got 0x%02x want 0xFF", got[1].Payload[0])
+	}
+
+	// Mutate returned copy — should not affect cache.
+	got[1].Payload[0] = 0xAA
+	got2 := c.get(0x00)
+	if got2[1].Payload[0] != 0xFF {
+		t.Errorf("cache was mutated via returned slice; got 0x%02x want 0xFF", got2[1].Payload[0])
+	}
+}
+
+func TestCacheTelemetryIDsNotCached(t *testing.T) {
+	c := newAdapterInfoCache()
+	frames := []downstream.Frame{
+		{Command: 0x0A, Payload: []byte{0x02}},
+		{Command: 0x0A, Payload: []byte{0x00}},
+		{Command: 0x0A, Payload: []byte{0x2D}},
+	}
+	c.put(0x03, frames) // Temperature — telemetry, should not cache
+
+	if got := c.get(0x03); got != nil {
+		t.Errorf("telemetry ID 0x03 should not be cached, got %v", got)
+	}
+}
+
+func TestCacheInvalidateAll(t *testing.T) {
+	c := newAdapterInfoCache()
+	for id := byte(0x00); id <= 0x02; id++ {
+		c.put(id, []downstream.Frame{
+			{Command: 0x0A, Payload: []byte{0x01}},
+			{Command: 0x0A, Payload: []byte{id}},
+		})
+	}
+
+	// Verify all cached.
+	for id := byte(0x00); id <= 0x02; id++ {
+		if c.get(id) == nil {
+			t.Fatalf("ID 0x%02x should be cached before invalidation", id)
+		}
+	}
+
+	c.invalidateAll()
+
+	// Verify all cleared.
+	for id := byte(0x00); id <= 0x02; id++ {
+		if c.get(id) != nil {
+			t.Errorf("ID 0x%02x should be nil after invalidation", id)
+		}
+	}
+}
+
+func TestCacheOverwrite(t *testing.T) {
+	c := newAdapterInfoCache()
+	c.put(0x00, []downstream.Frame{
+		{Command: 0x0A, Payload: []byte{0x01}},
+		{Command: 0x0A, Payload: []byte{0xAA}},
+	})
+	c.put(0x00, []downstream.Frame{
+		{Command: 0x0A, Payload: []byte{0x01}},
+		{Command: 0x0A, Payload: []byte{0xBB}},
+	})
+
+	got := c.get(0x00)
+	if got[1].Payload[0] != 0xBB {
+		t.Errorf("overwrite failed; got 0x%02x want 0xBB", got[1].Payload[0])
+	}
+}

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -87,6 +87,7 @@ type Server struct {
 
 	pendingInfoMu sync.Mutex
 	pendingInfo   *pendingInfo
+	infoCache     *adapterInfoCache
 
 	leasesMu     sync.Mutex
 	leaseManager *sourcepolicy.LeaseManager
@@ -106,6 +107,8 @@ type pendingStart struct {
 type pendingInfo struct {
 	sessionID uint64
 	remaining int
+	infoID    byte
+	frames    []downstream.Frame // accumulated response frames for caching
 }
 
 type pendingStartMode uint8
@@ -155,6 +158,7 @@ func NewServer(cfg Config) *Server {
 		startOfTelegram:     true,
 		observedInitiatorAt: make(map[byte]time.Time),
 		collisionBySession:  make(map[uint64]byte),
+		infoCache:           newAdapterInfoCache(),
 	}
 	server.busToken <- struct{}{}
 
@@ -782,10 +786,19 @@ func (server *Server) handleInfo(sessionID uint64, infoID byte) {
 		return
 	}
 
+	// Serve identity IDs from cache if available.
+	if cached := server.infoCache.get(infoID); cached != nil {
+		for _, f := range cached {
+			server.reply(sessionID, f)
+		}
+		return
+	}
+
 	server.pendingInfoMu.Lock()
 	server.pendingInfo = &pendingInfo{
 		sessionID: sessionID,
 		remaining: -1,
+		infoID:    infoID,
 	}
 	server.pendingInfoMu.Unlock()
 
@@ -1084,6 +1097,7 @@ func (server *Server) runUpstreamReader(ctx context.Context) {
 		case southboundenh.ENHResReceived, southboundenh.ENHResResetted:
 			if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResResetted && len(frame.Payload) == 1 {
 				server.upstreamFeatures.Store(uint32(frame.Payload[0]))
+				server.infoCache.invalidateAll()
 			}
 			if southboundenh.ENHCommand(frame.Command) == southboundenh.ENHResReceived && len(frame.Payload) == 1 {
 				server.lastWireRXAtNano.Store(time.Now().UTC().UnixNano())
@@ -1379,6 +1393,11 @@ func (server *Server) deliverPendingInfo(frame downstream.Frame) bool {
 		return true
 	}
 
+	// Collect frames for identity caching.
+	if isIdentityID(server.pendingInfo.infoID) {
+		server.pendingInfo.frames = append(server.pendingInfo.frames, frame)
+	}
+
 	if len(frame.Payload) != 1 {
 		return true
 	}
@@ -1386,6 +1405,10 @@ func (server *Server) deliverPendingInfo(frame downstream.Frame) bool {
 	if server.pendingInfo.remaining < 0 {
 		server.pendingInfo.remaining = int(frame.Payload[0])
 		if server.pendingInfo.remaining <= 0 {
+			// Cache completed identity response.
+			if isIdentityID(server.pendingInfo.infoID) {
+				server.infoCache.put(server.pendingInfo.infoID, server.pendingInfo.frames)
+			}
 			server.pendingInfo = nil
 		}
 		return true
@@ -1393,6 +1416,10 @@ func (server *Server) deliverPendingInfo(frame downstream.Frame) bool {
 
 	server.pendingInfo.remaining--
 	if server.pendingInfo.remaining <= 0 {
+		// Cache completed identity response.
+		if isIdentityID(server.pendingInfo.infoID) {
+			server.infoCache.put(server.pendingInfo.infoID, server.pendingInfo.frames)
+		}
 		server.pendingInfo = nil
 	}
 	return true


### PR DESCRIPTION
## Summary
- Cache identity INFO responses (IDs 0x00–0x02) with deep copy
- Telemetry IDs (0x03–0x07) always pass through uncached
- RESETTED handler invalidates all cached entries
- Wire into server: handleInfo serves from cache, deliverPendingInfo collects

## Test plan
- [x] 7 unit tests: state transitions, deep copy, telemetry bypass, invalidation, overwrite
- [x] `go test -race -count=1 ./...` passes

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)