### PR TITLE
PROXY-04: minimal direct-mode phase tracker (#88)

### DIFF
--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -96,6 +96,12 @@ type Server struct {
 	busWirePhase          busWirePhase
 	requestBytesSeen      int
 	requestDataLength     int
+	requestSrc            byte
+	requestDst            byte
+	requestPB             byte
+	requestSB             byte
+	requestLEN            byte
+	requestHeaderCaptured bool
 	responseBytesRemain   int
 	startArbSeq           uint64
 	startArbGrantSession  uint64
@@ -2096,6 +2102,12 @@ func (server *Server) resetBusWirePhaseLocked(phase busWirePhase) {
 	server.busWirePhase = phase
 	server.requestBytesSeen = 0
 	server.requestDataLength = -1
+	server.requestSrc = 0
+	server.requestDst = 0
+	server.requestPB = 0
+	server.requestSB = 0
+	server.requestLEN = 0
+	server.requestHeaderCaptured = false
 	server.responseBytesRemain = 0
 }
 
@@ -2105,7 +2117,18 @@ func (server *Server) advanceBusWirePhaseLocked(symbol byte) {
 		return
 	case busWirePhaseCollectRequest:
 		server.requestBytesSeen++
-		if server.requestBytesSeen == 5 {
+		switch server.requestBytesSeen {
+		case 1:
+			server.requestSrc = symbol
+		case 2:
+			server.requestDst = symbol
+		case 3:
+			server.requestPB = symbol
+		case 4:
+			server.requestSB = symbol
+		case 5:
+			server.requestLEN = symbol
+			server.requestHeaderCaptured = true
 			server.requestDataLength = int(symbol)
 			return
 		}

--- a/internal/adapterproxy/server_owner_release_test.go
+++ b/internal/adapterproxy/server_owner_release_test.go
@@ -315,6 +315,120 @@ func TestNoteBusWireSymbolReleasesOnSynWhileWaitingResponseAck(t *testing.T) {
 	}
 }
 
+func TestDirectModePhaseTrackerCapturesRequestHeaderAndLength(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(Config{})
+	server.setBusOwner(13, 0x31)
+
+	server.mutex.Lock()
+	server.resetBusWirePhaseLocked(busWirePhaseCollectRequest)
+	server.mutex.Unlock()
+
+	// request: SRC DST PB SB LEN D D CRC
+	request := []byte{0x31, 0x15, 0xB5, 0x09, 0x02, 0x44, 0x55, 0x6C}
+	for _, symbol := range request {
+		server.noteBusWireSymbol(symbol)
+	}
+
+	server.mutex.Lock()
+	phase := server.busWirePhase
+	bytesSeen := server.requestBytesSeen
+	dataLen := server.requestDataLength
+	src := server.requestSrc
+	dst := server.requestDst
+	pb := server.requestPB
+	sb := server.requestSB
+	length := server.requestLEN
+	headerCaptured := server.requestHeaderCaptured
+	server.mutex.Unlock()
+
+	if phase != busWirePhaseWaitCmdAck {
+		t.Fatalf("busWirePhase = %s; want %s", phase, busWirePhaseWaitCmdAck)
+	}
+	if bytesSeen != len(request) {
+		t.Fatalf("requestBytesSeen = %d; want %d", bytesSeen, len(request))
+	}
+	if dataLen != 2 {
+		t.Fatalf("requestDataLength = %d; want 2", dataLen)
+	}
+	if src != 0x31 || dst != 0x15 || pb != 0xB5 || sb != 0x09 || length != 0x02 {
+		t.Fatalf("captured header = src=0x%02X dst=0x%02X pb=0x%02X sb=0x%02X len=0x%02X; want 31 15 B5 09 02", src, dst, pb, sb, length)
+	}
+	if !headerCaptured {
+		t.Fatal("requestHeaderCaptured = false; want true")
+	}
+}
+
+func TestDirectModePhaseTrackerTransitionsRequestResponsePath(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(Config{})
+	server.setBusOwner(14, 0x31)
+
+	server.mutex.Lock()
+	server.resetBusWirePhaseLocked(busWirePhaseCollectRequest)
+	server.mutex.Unlock()
+
+	// request with zero request data bytes: SRC DST PB SB LEN CRC
+	for _, symbol := range []byte{0x31, 0x15, 0xB5, 0x00, 0x00, 0x42} {
+		server.noteBusWireSymbol(symbol)
+	}
+
+	server.mutex.Lock()
+	phase := server.busWirePhase
+	server.mutex.Unlock()
+	if phase != busWirePhaseWaitCmdAck {
+		t.Fatalf("busWirePhase = %s; want %s", phase, busWirePhaseWaitCmdAck)
+	}
+
+	server.noteBusWireSymbol(ebusACK)
+	server.mutex.Lock()
+	phase = server.busWirePhase
+	server.mutex.Unlock()
+	if phase != busWirePhaseWaitResponseLen {
+		t.Fatalf("busWirePhase after command ACK = %s; want %s", phase, busWirePhaseWaitResponseLen)
+	}
+
+	server.noteBusWireSymbol(0x02) // response length
+	server.mutex.Lock()
+	phase = server.busWirePhase
+	remain := server.responseBytesRemain
+	server.mutex.Unlock()
+	if phase != busWirePhaseWaitResponseBody {
+		t.Fatalf("busWirePhase after response LEN = %s; want %s", phase, busWirePhaseWaitResponseBody)
+	}
+	if remain != 3 {
+		t.Fatalf("responseBytesRemain = %d; want 3", remain)
+	}
+
+	server.noteBusWireSymbol(0x77) // response data #1
+	server.noteBusWireSymbol(0x88) // response data #2
+	server.noteBusWireSymbol(0x99) // response CRC
+	server.mutex.Lock()
+	phase = server.busWirePhase
+	server.mutex.Unlock()
+	if phase != busWirePhaseWaitResponseAck {
+		t.Fatalf("busWirePhase after response payload+CRC = %s; want %s", phase, busWirePhaseWaitResponseAck)
+	}
+
+	server.noteBusWireSymbol(ebusACK) // initiator confirms response
+	server.mutex.Lock()
+	phase = server.busWirePhase
+	bytesSeen := server.requestBytesSeen
+	headerCaptured := server.requestHeaderCaptured
+	server.mutex.Unlock()
+	if phase != busWirePhaseIdle {
+		t.Fatalf("busWirePhase after response ACK = %s; want %s", phase, busWirePhaseIdle)
+	}
+	if bytesSeen != 0 {
+		t.Fatalf("requestBytesSeen after reset = %d; want 0", bytesSeen)
+	}
+	if headerCaptured {
+		t.Fatal("requestHeaderCaptured = true after reset; want false")
+	}
+}
+
 func TestHandleSendDoesNotRefreshBusOwnershipTimestamp(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What\nAdd a minimal direct-mode L2 phase tracker for request/response boundary detection.\n\n## Why\nLater arbitration and responder gating need phase-aware timing without introducing L7 parsing.\n\n## Acceptance Criteria\n- [x] Tracker captures SRC, DST, PB, SB, LEN, request byte count, and response-phase transitions.\n- [x] No semantic payload parsing or L7 decode introduced.\n- [x] Tracker is used only for timing/scheduling boundary state tracking.\n- [x] Tests cover direct-mode request/response and timeout boundaries.\n\n## Validation\n- GOWORK=off go test ./internal/adapterproxy -run 'TestDirectModePhaseTrackerCapturesRequestHeaderAndLength|TestDirectModePhaseTrackerTransitionsRequestResponsePath|TestNoteBusWireSymbolReleasesOnSynWhileWaitingCommandAck|TestNoteBusWireSymbolReleasesOnSynWhileWaitingResponseBytes|TestNoteBusWireSymbolReleasesOnSynWhileWaitingResponseAck'\n- GOWORK=off go test ./internal/adapterproxy\n- GOWORK=off go test ./...\n\nCloses #88