### PR TITLE
feat(proxy): session initiator learning + admin status wiring (#89)

### DIFF
--- a/internal/adapterproxy/admin_status.go
+++ b/internal/adapterproxy/admin_status.go
@@ -1,0 +1,46 @@
+package adapterproxy
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/admin"
+)
+
+// Status implements admin.StatusProvider and exposes runtime session metadata
+// for the admin/status HTTP surface.
+func (server *Server) Status(_ context.Context) (admin.Status, error) {
+	server.mutex.Lock()
+	sessions := make([]admin.SessionStatus, 0, len(server.sessions))
+	for _, sess := range server.sessions {
+		sessionStatus := admin.SessionStatus{
+			ID:     fmt.Sprintf("%d", sess.id),
+			Client: sess.remoteAddr,
+			State:  sessionState(sess),
+		}
+		if learned, ok := server.learnedBySession[sess.id]; ok {
+			initiator := learned.Initiator
+			sessionStatus.Initiator = &initiator
+			sessionStatus.InitiatorSource = learned.Source
+			if !learned.LearnedAt.IsZero() {
+				sessionStatus.InitiatorLearnedAt = learned.LearnedAt.UTC().Format(time.RFC3339Nano)
+			}
+		}
+		sessions = append(sessions, sessionStatus)
+	}
+	server.mutex.Unlock()
+
+	return admin.Status{
+		Sessions: sessions,
+	}, nil
+}
+
+func sessionState(sess *session) string {
+	select {
+	case <-sess.done:
+		return "closed"
+	default:
+		return "connected"
+	}
+}

--- a/internal/adapterproxy/admin_status_test.go
+++ b/internal/adapterproxy/admin_status_test.go
@@ -1,0 +1,102 @@
+package adapterproxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/admin"
+	"github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/domain/downstream"
+)
+
+func TestServerStatusIncludesLearnedInitiatorMappings(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(Config{})
+	server.sessions = map[uint64]*session{
+		1: {id: 1, remoteAddr: "client-a", sendCh: make(chan downstream.Frame, 1), done: make(chan struct{})},
+		2: {id: 2, remoteAddr: "client-b", sendCh: make(chan downstream.Frame, 1), done: make(chan struct{})},
+	}
+
+	server.learnSessionInitiator(1, 0x31, "start")
+	server.learnSessionInitiator(2, 0x71, "request")
+
+	status, err := server.Status(context.Background())
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if len(status.Sessions) != 2 {
+		t.Fatalf("sessions len = %d; want 2", len(status.Sessions))
+	}
+
+	for _, sessionStatus := range status.Sessions {
+		switch sessionStatus.ID {
+		case "1":
+			if sessionStatus.Initiator == nil || *sessionStatus.Initiator != 0x31 {
+				t.Fatalf("session 1 initiator = %v; want 0x31", sessionStatus.Initiator)
+			}
+			if sessionStatus.InitiatorSource != "start" {
+				t.Fatalf("session 1 initiator_source = %q; want start", sessionStatus.InitiatorSource)
+			}
+			if sessionStatus.InitiatorLearnedAt == "" {
+				t.Fatal("session 1 initiator_learned_at empty; want RFC3339 timestamp")
+			}
+		case "2":
+			if sessionStatus.Initiator == nil || *sessionStatus.Initiator != 0x71 {
+				t.Fatalf("session 2 initiator = %v; want 0x71", sessionStatus.Initiator)
+			}
+			if sessionStatus.InitiatorSource != "request" {
+				t.Fatalf("session 2 initiator_source = %q; want request", sessionStatus.InitiatorSource)
+			}
+			if sessionStatus.InitiatorLearnedAt == "" {
+				t.Fatal("session 2 initiator_learned_at empty; want RFC3339 timestamp")
+			}
+		default:
+			t.Fatalf("unexpected session ID %q in status", sessionStatus.ID)
+		}
+	}
+}
+
+func TestAdminSessionsEndpointExposesLearnedInitiatorMappings(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(Config{})
+	server.sessions = map[uint64]*session{
+		1: {id: 1, remoteAddr: "client-a", sendCh: make(chan downstream.Frame, 1), done: make(chan struct{})},
+	}
+	server.learnSessionInitiator(1, 0x31, "start")
+
+	handler := admin.NewHandler(server)
+	request := httptest.NewRequest(http.MethodGet, "/sessions", nil)
+	responseRecorder := httptest.NewRecorder()
+	handler.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusOK {
+		t.Fatalf("status code = %d; want 200", responseRecorder.Code)
+	}
+
+	var payload map[string][]map[string]interface{}
+	if err := json.Unmarshal(responseRecorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode JSON payload: %v", err)
+	}
+	sessions := payload["sessions"]
+	if len(sessions) != 1 {
+		t.Fatalf("sessions len = %d; want 1", len(sessions))
+	}
+
+	session := sessions[0]
+	if got, ok := session["id"].(string); !ok || got != "1" {
+		t.Fatalf("sessions[0].id = %#v; want \"1\"", session["id"])
+	}
+	if got, ok := session["initiator"].(float64); !ok || uint8(got) != 0x31 {
+		t.Fatalf("sessions[0].initiator = %#v; want 49", session["initiator"])
+	}
+	if got, ok := session["initiator_source"].(string); !ok || got != "start" {
+		t.Fatalf("sessions[0].initiator_source = %#v; want \"start\"", session["initiator_source"])
+	}
+	if got, ok := session["initiator_learned_at"].(string); !ok || got == "" {
+		t.Fatalf("sessions[0].initiator_learned_at = %#v; want non-empty string", session["initiator_learned_at"])
+	}
+}

--- a/internal/adapterproxy/server.go
+++ b/internal/adapterproxy/server.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -84,6 +85,7 @@ type Server struct {
 	observedMu          sync.Mutex
 	observedInitiatorAt map[byte]time.Time
 	collisionBySession  map[uint64]byte
+	learnedBySession    map[uint64]sessionInitiatorLearning
 
 	busToken              chan struct{}
 	busOwner              uint64
@@ -146,6 +148,21 @@ type startArbContender struct {
 	initiator byte
 	seq       uint64
 	grantCh   chan struct{}
+}
+
+type sessionInitiatorLearning struct {
+	Initiator byte
+	LearnedAt time.Time
+	Source    string
+}
+
+// SessionInitiatorMapping provides an admin/status snapshot entry for learned
+// initiator identity per connected session.
+type SessionInitiatorMapping struct {
+	SessionID uint64
+	Initiator byte
+	LearnedAt time.Time
+	Source    string
 }
 
 type pendingStartMode uint8
@@ -232,6 +249,7 @@ func NewServer(cfg Config) *Server {
 		startOfTelegram:     true,
 		observedInitiatorAt: make(map[byte]time.Time),
 		collisionBySession:  make(map[uint64]byte),
+		learnedBySession:    make(map[uint64]sessionInitiatorLearning),
 		startArbContenders:  make(map[uint64]*startArbContender),
 		infoCache:           newAdapterInfoCache(),
 		upstreamLost:        make(chan struct{}),
@@ -407,6 +425,7 @@ func (server *Server) registerSession(connection net.Conn) *session {
 func (server *Server) unregisterSession(sessionID uint64) {
 	server.mutex.Lock()
 	delete(server.sessions, sessionID)
+	delete(server.learnedBySession, sessionID)
 	server.mutex.Unlock()
 
 	server.releaseBusIfOwner(sessionID)
@@ -505,7 +524,12 @@ func (server *Server) handleStart(ctx context.Context, sessionID uint64, initiat
 	}
 
 	if initiator == 0x00 {
-		if leasedAddress, ok := server.sessionLeaseAddress(sessionID); ok {
+		if learnedAddress, ok := server.sessionLearnedInitiator(sessionID); ok {
+			initiator = learnedAddress
+			if server.cfg.Debug {
+				log.Printf("session=%d auto_join_reuse_learned=0x%02X", sessionID, learnedAddress)
+			}
+		} else if leasedAddress, ok := server.sessionLeaseAddress(sessionID); ok {
 			initiator = leasedAddress
 			if server.cfg.Debug {
 				log.Printf("session=%d auto_join_reuse_lease=0x%02X", sessionID, leasedAddress)
@@ -1941,6 +1965,7 @@ func (server *Server) setBusOwner(sessionID uint64, initiator byte) {
 	server.busDirty = true
 	server.busOwned = time.Now().UTC()
 	server.resetBusWirePhaseLocked(busWirePhaseIdle)
+	server.learnSessionInitiatorLocked(sessionID, initiator, "start")
 	server.mutex.Unlock()
 }
 
@@ -2136,6 +2161,7 @@ func (server *Server) advanceBusWirePhaseLocked(symbol byte) {
 			return
 		}
 		if server.requestBytesSeen >= 6+server.requestDataLength {
+			server.learnSessionInitiatorLocked(server.busOwner, server.requestSrc, "request")
 			server.busWirePhase = busWirePhaseWaitCmdAck
 		}
 	case busWirePhaseWaitCmdAck:
@@ -2420,6 +2446,65 @@ func (server *Server) takeSessionCollision(sessionID uint64) (byte, bool) {
 	}
 	delete(server.collisionBySession, sessionID)
 	return winner, true
+}
+
+func (server *Server) learnSessionInitiator(sessionID uint64, initiator byte, source string) {
+	server.mutex.Lock()
+	server.learnSessionInitiatorLocked(sessionID, initiator, source)
+	server.mutex.Unlock()
+}
+
+func (server *Server) learnSessionInitiatorLocked(sessionID uint64, initiator byte, source string) {
+	if sessionID == 0 || sessionID == udpBridgeOwnerID {
+		return
+	}
+	if !isInitiatorAddress(initiator) {
+		return
+	}
+	if _, ok := server.sessions[sessionID]; !ok {
+		return
+	}
+	if source == "" {
+		source = "unknown"
+	}
+
+	server.learnedBySession[sessionID] = sessionInitiatorLearning{
+		Initiator: initiator,
+		LearnedAt: time.Now().UTC(),
+		Source:    source,
+	}
+}
+
+func (server *Server) sessionLearnedInitiator(sessionID uint64) (byte, bool) {
+	server.mutex.Lock()
+	defer server.mutex.Unlock()
+
+	learning, ok := server.learnedBySession[sessionID]
+	if !ok {
+		return 0, false
+	}
+	return learning.Initiator, true
+}
+
+// SessionInitiatorMappings exposes learned session->initiator identity for
+// status/admin surfaces.
+func (server *Server) SessionInitiatorMappings() []SessionInitiatorMapping {
+	server.mutex.Lock()
+	mappings := make([]SessionInitiatorMapping, 0, len(server.learnedBySession))
+	for sessionID, learning := range server.learnedBySession {
+		mappings = append(mappings, SessionInitiatorMapping{
+			SessionID: sessionID,
+			Initiator: learning.Initiator,
+			LearnedAt: learning.LearnedAt,
+			Source:    learning.Source,
+		})
+	}
+	server.mutex.Unlock()
+
+	sort.Slice(mappings, func(i, j int) bool {
+		return mappings[i].SessionID < mappings[j].SessionID
+	})
+	return mappings
 }
 
 func isInitiatorAddress(address byte) bool {

--- a/internal/adapterproxy/server_owner_release_test.go
+++ b/internal/adapterproxy/server_owner_release_test.go
@@ -957,6 +957,14 @@ func TestHandleStartArbitrationEqualInitiatorKeepsFIFO(t *testing.T) {
 		defer close(firstDone)
 		server.handleStart(ctx, 1, 0x31)
 	}()
+	if !waitUntil(300*time.Millisecond, func() bool {
+		server.mutex.Lock()
+		defer server.mutex.Unlock()
+		_, hasFirst := server.startArbContenders[1]
+		return len(server.startArbContenders) == 1 && hasFirst
+	}) {
+		t.Fatalf("expected first equal-initiator contender before second joins")
+	}
 	go func() {
 		defer close(secondDone)
 		server.handleStart(ctx, 2, 0x31)
@@ -1007,6 +1015,216 @@ func TestHandleStartArbitrationEqualInitiatorKeepsFIFO(t *testing.T) {
 
 	_ = upstream.Close()
 	server.waitGroup.Wait()
+}
+
+func TestHandleStartAutoJoinReusesLearnedInitiator(t *testing.T) {
+	t.Parallel()
+
+	upstream := newDeterministicStartUpstream()
+	server := NewServer(Config{UpstreamTransport: UpstreamENH})
+	server.upstream = upstream
+	server.leaseManager = nil
+	server.sessions = map[uint64]*session{
+		1: {id: 1, sendCh: make(chan downstream.Frame, 8), done: make(chan struct{})},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		server.handleStart(ctx, 1, 0x31)
+	}()
+
+	select {
+	case frame := <-upstream.writeCh:
+		if southboundenh.ENHCommand(frame.Command) != southboundenh.ENHReqStart {
+			t.Fatalf("first upstream command = 0x%02X; want ENHReqStart", frame.Command)
+		}
+		if len(frame.Payload) != 1 || frame.Payload[0] != 0x31 {
+			t.Fatalf("first START payload = %x; want [31]", frame.Payload)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first START write not observed")
+	}
+
+	select {
+	case <-firstDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first START did not complete")
+	}
+
+	server.releaseBusIfOwner(1)
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		server.handleStart(ctx, 1, 0x00)
+	}()
+
+	select {
+	case frame := <-upstream.writeCh:
+		if southboundenh.ENHCommand(frame.Command) != southboundenh.ENHReqStart {
+			t.Fatalf("second upstream command = 0x%02X; want ENHReqStart", frame.Command)
+		}
+		if len(frame.Payload) != 1 || frame.Payload[0] != 0x31 {
+			t.Fatalf("second START payload = %x; want learned [31]", frame.Payload)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("second START write not observed")
+	}
+
+	select {
+	case <-secondDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("second START did not complete")
+	}
+
+	mappings := server.SessionInitiatorMappings()
+	if len(mappings) != 1 {
+		t.Fatalf("learned mappings len = %d; want 1", len(mappings))
+	}
+	if mappings[0].SessionID != 1 || mappings[0].Initiator != 0x31 {
+		t.Fatalf(
+			"mapping[0] = session=%d initiator=0x%02X; want session=1 initiator=0x31",
+			mappings[0].SessionID,
+			mappings[0].Initiator,
+		)
+	}
+	if mappings[0].Source != "start" {
+		t.Fatalf("mapping[0] source = %q; want start", mappings[0].Source)
+	}
+
+	cancel()
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestHandleStartArbitrationUsesLearnedInitiatorIdentity(t *testing.T) {
+	t.Parallel()
+
+	upstream := newDeterministicStartUpstream()
+	server := NewServer(Config{UpstreamTransport: UpstreamENH})
+	server.upstream = upstream
+	server.leaseManager = nil
+	server.sessions = map[uint64]*session{
+		1: {id: 1, sendCh: make(chan downstream.Frame, 8), done: make(chan struct{})},
+		2: {id: 2, sendCh: make(chan downstream.Frame, 8), done: make(chan struct{})},
+	}
+	server.setBusOwner(99, 0x10)
+
+	select {
+	case <-server.busToken:
+	default:
+		t.Fatalf("expected initial bus token")
+	}
+
+	server.learnSessionInitiator(1, 0x71, "start")
+	server.learnSessionInitiator(2, 0x31, "start")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	server.waitGroup.Add(1)
+	go server.runUpstreamReader(ctx)
+
+	highDone := make(chan struct{})
+	lowDone := make(chan struct{})
+	go func() {
+		defer close(highDone)
+		server.handleStart(ctx, 1, 0x00)
+	}()
+	go func() {
+		defer close(lowDone)
+		server.handleStart(ctx, 2, 0x00)
+	}()
+
+	if !waitUntil(300*time.Millisecond, func() bool {
+		server.mutex.Lock()
+		defer server.mutex.Unlock()
+		return len(server.startArbContenders) == 2
+	}) {
+		t.Fatalf("expected two auto-join contenders before boundary release")
+	}
+
+	server.releaseBusIfOwner(99)
+
+	select {
+	case frame := <-upstream.writeCh:
+		if southboundenh.ENHCommand(frame.Command) != southboundenh.ENHReqStart {
+			t.Fatalf("first upstream command = 0x%02X; want ENHReqStart", frame.Command)
+		}
+		if len(frame.Payload) != 1 || frame.Payload[0] != 0x31 {
+			t.Fatalf("first START payload = %x; want learned lower [31]", frame.Payload)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("expected first START write after boundary release")
+	}
+
+	select {
+	case <-lowDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("lower learned-initiator START did not complete")
+	}
+
+	cancel()
+	select {
+	case <-highDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("higher learned-initiator START did not exit after cancellation")
+	}
+
+	_ = upstream.Close()
+	server.waitGroup.Wait()
+}
+
+func TestSessionInitiatorMappingsReflectRequestLearningAndUnregister(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(Config{})
+	server.sessions = map[uint64]*session{
+		1: {id: 1, sendCh: make(chan downstream.Frame, 1), done: make(chan struct{})},
+		2: {id: 2, sendCh: make(chan downstream.Frame, 1), done: make(chan struct{})},
+	}
+
+	server.learnSessionInitiator(2, 0x71, "start")
+	server.setBusOwner(1, 0x00)
+
+	server.mutex.Lock()
+	server.resetBusWirePhaseLocked(busWirePhaseCollectRequest)
+	server.mutex.Unlock()
+	for _, symbol := range []byte{0x31, 0x15, 0xB5, 0x00, 0x00, 0x42} {
+		server.noteBusWireSymbol(symbol)
+	}
+
+	mappings := server.SessionInitiatorMappings()
+	if len(mappings) != 2 {
+		t.Fatalf("learned mappings len = %d; want 2", len(mappings))
+	}
+	if mappings[0].SessionID != 1 || mappings[0].Initiator != 0x31 || mappings[0].Source != "request" {
+		t.Fatalf(
+			"mapping[0] = session=%d initiator=0x%02X source=%q; want session=1 initiator=0x31 source=request",
+			mappings[0].SessionID,
+			mappings[0].Initiator,
+			mappings[0].Source,
+		)
+	}
+	if mappings[1].SessionID != 2 || mappings[1].Initiator != 0x71 || mappings[1].Source != "start" {
+		t.Fatalf(
+			"mapping[1] = session=%d initiator=0x%02X source=%q; want session=2 initiator=0x71 source=start",
+			mappings[1].SessionID,
+			mappings[1].Initiator,
+			mappings[1].Source,
+		)
+	}
+
+	server.unregisterSession(1)
+	server.unregisterSession(2)
+	if got := len(server.SessionInitiatorMappings()); got != 0 {
+		t.Fatalf("learned mappings after unregister len = %d; want 0", got)
+	}
 }
 
 func waitUntil(timeout time.Duration, condition func() bool) bool {

--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -16,8 +16,22 @@ func TestReadOnlyEndpointsReturnStableSchemas(t *testing.T) {
 	statusProvider := stubStatusProvider{
 		status: Status{
 			Sessions: []SessionStatus{
-				{ID: "s-2", Client: "client-b", State: "idle"},
-				{ID: "s-1", Client: "client-a", State: "active"},
+				{
+					ID:                 "s-2",
+					Client:             "client-b",
+					State:              "idle",
+					Initiator:          uint8ptr(0x71),
+					InitiatorSource:    "start",
+					InitiatorLearnedAt: "2026-04-04T19:00:00Z",
+				},
+				{
+					ID:                 "s-1",
+					Client:             "client-a",
+					State:              "active",
+					Initiator:          uint8ptr(0x31),
+					InitiatorSource:    "request",
+					InitiatorLearnedAt: "2026-04-04T19:05:00Z",
+				},
 			},
 			Scheduler: SchedulerStatus{
 				Running:      true,
@@ -68,8 +82,22 @@ func TestReadOnlyEndpointsReturnStableSchemas(t *testing.T) {
 				}
 
 				expectedSessions := []SessionStatus{
-					{ID: "s-1", Client: "client-a", State: "active"},
-					{ID: "s-2", Client: "client-b", State: "idle"},
+					{
+						ID:                 "s-1",
+						Client:             "client-a",
+						State:              "active",
+						Initiator:          uint8ptr(0x31),
+						InitiatorSource:    "request",
+						InitiatorLearnedAt: "2026-04-04T19:05:00Z",
+					},
+					{
+						ID:                 "s-2",
+						Client:             "client-b",
+						State:              "idle",
+						Initiator:          uint8ptr(0x71),
+						InitiatorSource:    "start",
+						InitiatorLearnedAt: "2026-04-04T19:00:00Z",
+					},
 				}
 				if !reflect.DeepEqual(response.Sessions, expectedSessions) {
 					t.Fatalf("expected sorted sessions %#v, got %#v", expectedSessions, response.Sessions)
@@ -81,7 +109,14 @@ func TestReadOnlyEndpointsReturnStableSchemas(t *testing.T) {
 					"sessions",
 					0,
 				)
-				assertObjectKeys(t, firstSessionObject, []string{"id", "client", "state"})
+				assertObjectKeys(t, firstSessionObject, []string{
+					"id",
+					"client",
+					"state",
+					"initiator",
+					"initiator_source",
+					"initiator_learned_at",
+				})
 			},
 		},
 		{
@@ -350,4 +385,8 @@ func assertObjectKeys(t *testing.T, object map[string]interface{}, expectedKeys 
 	if !reflect.DeepEqual(actualKeys, sortedExpectedKeys) {
 		t.Fatalf("expected keys %v, got %v", sortedExpectedKeys, actualKeys)
 	}
+}
+
+func uint8ptr(value uint8) *uint8 {
+	return &value
 }

--- a/internal/admin/status.go
+++ b/internal/admin/status.go
@@ -12,9 +12,12 @@ type Status struct {
 }
 
 type SessionStatus struct {
-	ID     string `json:"id"`
-	Client string `json:"client"`
-	State  string `json:"state"`
+	ID                 string `json:"id"`
+	Client             string `json:"client"`
+	State              string `json:"state"`
+	Initiator          *uint8 `json:"initiator,omitempty"`
+	InitiatorSource    string `json:"initiator_source,omitempty"`
+	InitiatorLearnedAt string `json:"initiator_learned_at,omitempty"`
 }
 
 type SchedulerStatus struct {


### PR DESCRIPTION
## What
- learn  identity from successful start/request activity
- reuse learned initiator for  path before lease/auto-select fallback
- expose learned initiator mapping in admin  status surface

## Why
- closes #89 acceptance criterion that admin/status must expose learned initiator mappings
- keeps scope tight to #89 without introducing ENS/ENH manual claim extensions

## Validation
- ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/adapterproxy	(cached)
- ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/admin	(cached)
- ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/adapterproxy	(cached)
- ?   	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/cmd/ebusd-compat-harness	[no test files]
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/cmd/helianthus-ebus-adapter-proxy	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/adapterproxy	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/admin	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/compat/ebusd	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/config	(cached)
?   	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/domain/downstream	[no test files]
?   	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/domain/routing	[no test files]
?   	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/domain/upstream	[no test files]
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/emulation/targets	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/northbound/enh	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/northbound/ens	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/proxy	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/scheduler/write	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/session	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/sourcepolicy	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/southbound/enh	(cached)
ok  	github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/internal/southbound/ens	(cached)