### PR TITLE
TEST-01: Matrix and smoke expansion for wire-semantics proxy (proxy lane)

### DIFF
--- a/OPERATIONS_RUNBOOK.md
+++ b/OPERATIONS_RUNBOOK.md
@@ -49,7 +49,9 @@ Goal: keep the legacy `ebusd` path stable while onboarding Helianthus traffic th
    - Start/upgrade proxy with intended profile endpoint(s) and unchanged `ebusd` direct endpoint.
 4. **Run operator smoke procedures**
    - Execute commands in [Operator smoke procedures](#operator-smoke-procedures).
-5. **Promote only on PASS markers**
+5. **Run matrix proof gates (transport + proxy semantics adjunct)**
+   - Execute command in [Matrix proof procedures](#matrix-proof-procedures).
+6. **Promote only on PASS markers**
    - Promote rollout only if expected PASS markers are present.
 
 ## Fail-closed behavior
@@ -154,6 +156,33 @@ Expected readiness markers:
 PASS: gateway readiness dual-topology path ebusd_endpoint=tcp://127.0.0.1:8888 proxy_endpoint=<enh|ens>://127.0.0.1:<port>
 PASS: ha integration dual-topology smoke completed for proxy profile <enh|ens>
 ```
+
+## Matrix proof procedures
+
+Run matrix gate validation using both inventories. `T01..T88` remains the primary transport gate. `PX01..PX12` is a required adjunct for proxy wire-semantics behavior.
+
+```bash
+TRANSPORT_MATRIX_REPORT=artifacts/transport-matrix-index.json \
+PROXY_SEMANTICS_MATRIX_REPORT=artifacts/proxy-semantics-matrix-index.json \
+./scripts/transport_gate.sh
+```
+
+Expected markers:
+
+```text
+transport gate: PASS (pass=..., xfail=..., xpass=..., blocked=..., total=88).
+proxy semantics gate: PASS (pass=..., xfail=..., xpass=0, blocked=..., total=12).
+```
+
+Evidence requirements:
+- `proxy-semantics-matrix-index.json` must contain exactly `PX01..PX12`.
+- `xpass` is not allowed in the proxy semantics inventory.
+- Unexpected `fail` or `planned` outcomes fail the gate.
+- Case definitions are documented in `profiles/proxy-wire-semantics/px-cases.md`.
+
+Deferred hardware proof:
+- This runbook does not claim hardware-backed ESERA passive validation for M5 merges.
+- Hardware validation remains deferred under issue `Project-Helianthus/helianthus-docs-ebus#241`.
 
 ## Rollback quick steps
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ Use when `../helianthus-ha-integration` is available for coexistence checks:
 - `profiles/gateway-direct-proxy/agent-local.enh.md`
 - `profiles/gateway-direct-proxy/agent-local.ens.md`
 
+### D) Proxy semantics matrix adjunct (issue #91)
+
+- `profiles/proxy-wire-semantics/px-cases.md`
+- `profiles/proxy-wire-semantics/proxy-semantics-matrix-example.json`
+
 ## Validation Commands
 
 | Area | Command |
@@ -134,6 +139,7 @@ Use when `../helianthus-ha-integration` is available for coexistence checks:
 | tests | `GOWORK=off go test ./...` |
 | vet | `GOWORK=off go vet ./...` |
 | terminology gate | `./scripts/terminology-gate.sh` |
+| transport + proxy semantics matrix gate | `TRANSPORT_MATRIX_REPORT=<transport-index.json> PROXY_SEMANTICS_MATRIX_REPORT=<proxy-semantics-index.json> ./scripts/transport_gate.sh` |
 | operations runbook gate | `./scripts/verify_issue21_runbook.sh` |
 | compatibility harness | `go run ./cmd/ebusd-compat-harness --timeout 10s` |
 | gateway smoke CLI help | `./scripts/run-gateway-direct-proxy-smoke.sh --help` |

--- a/profiles/proxy-wire-semantics/proxy-semantics-matrix-example.json
+++ b/profiles/proxy-wire-semantics/proxy-semantics-matrix-example.json
@@ -1,0 +1,19 @@
+{
+  "suite": "proxy-wire-semantics",
+  "version": "v1",
+  "deferred_hardware_followup": "Project-Helianthus/helianthus-docs-ebus#241",
+  "cases": [
+    { "case_id": "PX01", "outcome": "pass" },
+    { "case_id": "PX02", "outcome": "pass" },
+    { "case_id": "PX03", "outcome": "pass" },
+    { "case_id": "PX04", "outcome": "pass" },
+    { "case_id": "PX05", "outcome": "pass" },
+    { "case_id": "PX06", "outcome": "pass" },
+    { "case_id": "PX07", "outcome": "pass" },
+    { "case_id": "PX08", "outcome": "pass" },
+    { "case_id": "PX09", "outcome": "pass" },
+    { "case_id": "PX10", "outcome": "pass" },
+    { "case_id": "PX11", "outcome": "pass" },
+    { "case_id": "PX12", "outcome": "pass" }
+  ]
+}

--- a/profiles/proxy-wire-semantics/px-cases.md
+++ b/profiles/proxy-wire-semantics/px-cases.md
@@ -1,0 +1,31 @@
+# Proxy Wire-Semantics PX Case Set
+
+This file defines the adjunct proxy semantics matrix that must be validated alongside the transport matrix (`T01..T88`).
+
+Primary gate:
+- `T01..T88` (transport/protocol matrix)
+
+Required adjunct:
+- `PX01..PX12` (proxy wire-semantics matrix)
+
+Case inventory:
+
+| Case | Focus |
+|---|---|
+| `PX01` | stale `STARTED` absorb succeeds when matching result arrives in absorb window |
+| `PX02` | stale `STARTED` absorb expires via bounded fail path |
+| `PX03` | `SYN` while waiting for command `ACK` reopens arbitration immediately |
+| `PX04` | `SYN` while waiting for target response bytes reopens arbitration immediately |
+| `PX05` | lower initiator wins same-boundary competition |
+| `PX06` | queued higher initiator loses when lower initiator arrives before next round closes |
+| `PX07` | requeue-after-timeout by former owner still wins by lower initiator priority |
+| `PX08` | equal-initiator FIFO ordering is preserved |
+| `PX09` | local target observes request only from echoed `RECEIVED` path, never from owner `SEND` intent |
+| `PX10` | local emulated target response inside responder window remains coherent |
+| `PX11` | late responder bytes are rejected and counted |
+| `PX12` | non-owner/non-responder sends are rejected during active transaction |
+
+Outcome policy:
+- Allowed outcomes: `pass`, `xfail`, `blocked-infra`
+- `xpass` is not allowed for `PX` inventory.
+- `blocked-infra` is allowed only with `infra_reason=adapter_no_signal`.

--- a/scripts/runbook-gate.sh
+++ b/scripts/runbook-gate.sh
@@ -16,6 +16,7 @@ required_patterns=(
 	"## Fail-closed behavior"
 	"## Recovery steps"
 	"## Operator smoke procedures"
+	"## Matrix proof procedures"
 	"RESULT: PASS \\(config-only migration verified; no ebusd patch required\\)"
 	"PASS: gateway path readiness profile=<enh\\|ens> endpoint=<enh\\|ens>://127.0.0.1:<port>"
 	"FAIL: gateway path readiness profile=<enh\\|ens> endpoint=<enh\\|ens>://\\.\\.\\."
@@ -24,6 +25,11 @@ required_patterns=(
 	"PASS: gateway readiness dual-topology path ebusd_endpoint=tcp://127.0.0.1:8888 proxy_endpoint=<enh\\|ens>://127.0.0.1:<port>"
 	"FAIL: gateway readiness dual-topology path \\.\\.\\."
 	"PASS: ha integration dual-topology smoke completed for proxy profile <enh\\|ens>"
+	"TRANSPORT_MATRIX_REPORT=artifacts/transport-matrix-index.json"
+	"PROXY_SEMANTICS_MATRIX_REPORT=artifacts/proxy-semantics-matrix-index.json"
+	"transport gate: PASS \\(pass=\\.\\.\\., xfail=\\.\\.\\., xpass=\\.\\.\\., blocked=\\.\\.\\., total=88\\)\\."
+	"proxy semantics gate: PASS \\(pass=\\.\\.\\., xfail=\\.\\.\\., xpass=0, blocked=\\.\\.\\., total=12\\)\\."
+	"Project-Helianthus/helianthus-docs-ebus#241"
 )
 
 if command -v rg >/dev/null 2>&1; then
@@ -46,4 +52,3 @@ for pattern in "${required_patterns[@]}"; do
 done
 
 echo "PASS: operations runbook markers verified"
-

--- a/scripts/transport_gate.sh
+++ b/scripts/transport_gate.sh
@@ -35,6 +35,12 @@ while IFS= read -r file; do
 done <<< "${changed_files}"
 
 if [[ "${requires_gate}" -eq 0 ]]; then
+  if [[ "${TRANSPORT_GATE_FORCE:-}" == "1" ]]; then
+    requires_gate=1
+  fi
+fi
+
+if [[ "${requires_gate}" -eq 0 ]]; then
   echo "transport gate: not triggered."
   exit 0
 fi
@@ -58,12 +64,24 @@ if [[ ! -f "${report_path}" ]]; then
   exit 1
 fi
 
-python3 - "${report_path}" <<'PY'
+proxy_report_path="${PROXY_SEMANTICS_MATRIX_REPORT:-}"
+if [[ -z "${proxy_report_path}" ]]; then
+  echo "transport gate: PROXY_SEMANTICS_MATRIX_REPORT is required for transport/protocol changes."
+  exit 1
+fi
+if [[ ! -f "${proxy_report_path}" ]]; then
+  echo "transport gate: proxy semantics report not found at ${proxy_report_path}."
+  exit 1
+fi
+
+python3 - "${report_path}" "${proxy_report_path}" <<'PY'
 import json
 import sys
 
-path = sys.argv[1]
-with open(path, "r", encoding="utf-8") as handle:
+transport_path = sys.argv[1]
+proxy_path = sys.argv[2]
+
+with open(transport_path, "r", encoding="utf-8") as handle:
     payload = json.load(handle)
 
 cases = payload.get("cases")
@@ -123,4 +141,75 @@ msg = f"transport gate: PASS (pass={passed}, xfail={xfailed}, xpass={xpassed}, b
 if xpassed:
     msg += " review expected-failure list (xpass present)."
 print(msg)
+
+with open(proxy_path, "r", encoding="utf-8") as handle:
+    proxy_payload = json.load(handle)
+
+proxy_cases = proxy_payload.get("cases")
+if not isinstance(proxy_cases, list):
+    print("proxy semantics gate: invalid matrix report (missing cases list).")
+    raise SystemExit(1)
+if len(proxy_cases) != 12:
+    print(f"proxy semantics gate: expected 12 cases, got {len(proxy_cases)}.")
+    raise SystemExit(1)
+
+expected_proxy_ids = [f"PX{i:02d}" for i in range(1, 13)]
+seen_proxy_ids = [str(case.get("case_id", "")) for case in proxy_cases]
+missing_proxy_ids = sorted(set(expected_proxy_ids) - set(seen_proxy_ids))
+extra_proxy_ids = sorted(set(seen_proxy_ids) - set(expected_proxy_ids))
+duplicate_proxy_ids = sorted({case_id for case_id in seen_proxy_ids if seen_proxy_ids.count(case_id) > 1})
+if missing_proxy_ids or extra_proxy_ids or duplicate_proxy_ids:
+    details = []
+    if missing_proxy_ids:
+        details.append(f"missing={','.join(missing_proxy_ids)}")
+    if extra_proxy_ids:
+        details.append(f"extra={','.join(extra_proxy_ids)}")
+    if duplicate_proxy_ids:
+        details.append(f"duplicate={','.join(duplicate_proxy_ids)}")
+    print(f"proxy semantics gate: invalid case inventory ({'; '.join(details)}).")
+    raise SystemExit(1)
+
+proxy_unexpected = []
+proxy_xfailed = 0
+proxy_xpassed = 0
+proxy_passed = 0
+proxy_blocked = 0
+proxy_blocked_invalid = []
+
+for case in proxy_cases:
+    value = normalized_outcome(case)
+    case_id = case.get("case_id", "?")
+    if value == "pass":
+        proxy_passed += 1
+    elif value == "xfail":
+        proxy_xfailed += 1
+    elif value == "xpass":
+        proxy_xpassed += 1
+    elif value == "blocked-infra":
+        reason = str(case.get("infra_reason", "")).strip()
+        if reason != "adapter_no_signal":
+            proxy_blocked_invalid.append((case_id, reason))
+            continue
+        proxy_blocked += 1
+    else:
+        proxy_unexpected.append(case_id)
+
+if proxy_blocked_invalid:
+    preview = ",".join(f"{case_id}:{reason or 'missing'}" for case_id, reason in proxy_blocked_invalid[:10])
+    print(f"proxy semantics gate: blocked-infra has unsupported reason ({len(proxy_blocked_invalid)}). sample={preview}")
+    raise SystemExit(1)
+
+if proxy_unexpected:
+    preview = ",".join(proxy_unexpected[:10])
+    print(f"proxy semantics gate: unexpected failures/planned ({len(proxy_unexpected)}). sample={preview}")
+    raise SystemExit(1)
+
+if proxy_xpassed:
+    print(f"proxy semantics gate: xpass is not allowed (xpass={proxy_xpassed}).")
+    raise SystemExit(1)
+
+print(
+    "proxy semantics gate: PASS "
+    f"(pass={proxy_passed}, xfail={proxy_xfailed}, xpass={proxy_xpassed}, blocked={proxy_blocked}, total={len(proxy_cases)})."
+)
 PY


### PR DESCRIPTION
Implements #91.\n\n## What\n- Adds proxy semantics adjunct inventory PX01..PX12 in this repo\n- Extends transport gate wiring to require both reports: T01..T88 and PX01..PX12\n- Updates runbook/runbook-gate and README with required proof flow\n\n## Why\nTransport/protocol merges in this EPIC require T01..T88 as primary gate plus PX01..PX12 as required adjunct for proxy wire-semantics behavior.\n\n## Acceptance\n- [x] Proxy-focused PX01..PX12 matrix/smoke cases added (inventory + example report)\n- [x] Proxy CI/runbook gate wiring updated to require PX report alongside T report\n- [x] Gate rejects unexpected fail/planned and rejects PX xpass\n- [x] ESERA hardware proof remains deferred and linked (docs issue #241)\n\n## Validation\n- ./scripts/runbook-gate.sh\n- TRANSPORT_GATE_FORCE=1 TRANSPORT_MATRIX_REPORT=/tmp/transport-matrix-index.json PROXY_SEMANTICS_MATRIX_REPORT=/tmp/proxy-semantics-matrix-index.json ./scripts/transport_gate.sh\n- Negative check: same command with PX xpass report (fails as expected)\n- ./scripts/ci_local.sh\n\nFixes #91